### PR TITLE
Simplify React client optimizer config

### DIFF
--- a/packages/vitest-plugin-rsc/src/index.ts
+++ b/packages/vitest-plugin-rsc/src/index.ts
@@ -1,9 +1,7 @@
 import {
   type Plugin,
-  type PluginOption,
   type UserConfig,
   type ViteDevServer,
-  version as viteVersion,
 } from "vite";
 import { vitePluginRscMinimal } from "@vitejs/plugin-rsc/plugin";
 
@@ -31,26 +29,23 @@ type ReactClientWebSocketPayload = {
   };
 };
 
-function isPlugin(plugin: PluginOption): plugin is Plugin {
+function isPlugin(plugin: unknown): plugin is Plugin {
   return !!plugin && typeof plugin === "object" && "name" in plugin;
 }
 
-function flattenPluginNames(plugins: PluginOption[] | undefined): string[] {
-  const names: string[] = [];
-
+function hasPlugin(plugins: UserConfig["plugins"], pluginName: string): boolean {
   for (const plugin of plugins ?? []) {
     if (Array.isArray(plugin)) {
-      names.push(...flattenPluginNames(plugin));
+      if (hasPlugin(plugin, pluginName)) return true;
     } else if (isPlugin(plugin)) {
-      names.push(plugin.name);
+      if (plugin.name === pluginName) return true;
     }
   }
-
-  return names;
+  return false;
 }
 
 function isVitestBrowserServer(config: UserConfig): boolean {
-  return flattenPluginNames(config.plugins).includes("vitest:browser");
+  return hasPlugin(config.plugins, "vitest:browser");
 }
 
 function disableOptimizer(config: UserConfig, environmentName: string): void {
@@ -61,24 +56,6 @@ function disableOptimizer(config: UserConfig, environmentName: string): void {
   optimizeDeps.noDiscovery = true;
   optimizeDeps.include = [];
   optimizeDeps.entries = [];
-}
-
-function getReactClientOptimizerBundlerOptions() {
-  const viteMajor = Number(viteVersion.split(".")[0]);
-
-  if (viteMajor >= 8) {
-    return {
-      rolldownOptions: {
-        platform: "browser",
-      },
-    };
-  }
-
-  return {
-    esbuildOptions: {
-      platform: "browser",
-    },
-  };
 }
 
 export function vitestPluginRSC(): Plugin[] {
@@ -187,7 +164,6 @@ export function vitestPluginRSC(): Plugin[] {
                 ],
                 noDiscovery: false,
                 exclude: ["vitest-plugin-rsc", "@vitejs/plugin-rsc"],
-                ...getReactClientOptimizerBundlerOptions(),
               },
             },
           },

--- a/packages/vitest-plugin-rsc/src/index.ts
+++ b/packages/vitest-plugin-rsc/src/index.ts
@@ -1,8 +1,4 @@
-import {
-  type Plugin,
-  type UserConfig,
-  type ViteDevServer,
-} from "vite";
+import { type Plugin, type UserConfig, type ViteDevServer } from "vite";
 import { vitePluginRscMinimal } from "@vitejs/plugin-rsc/plugin";
 
 const REACT_CLIENT_OPTIMIZE_DEPS_ENTRIES = [
@@ -11,7 +7,6 @@ const REACT_CLIENT_OPTIMIZE_DEPS_ENTRIES = [
   "components/**/*.{js,jsx,ts,tsx}",
 ];
 
-const reactClientInvokePath = "/@vite/invoke-react-client";
 const reactClientWebSocketInfoPath = "/@vite/react-client-runner-websocket";
 const reactClientWebSocketQuery = "vitest-plugin-rsc-react-client";
 const reactClientWebSocketInvokeEvent = "vitest-plugin-rsc:react-client:invoke";
@@ -20,20 +15,19 @@ const reactClientWebSocketInvokeResultEvent =
 type ReactClientInvokePayload = Parameters<
   ViteDevServer["environments"][string]["hot"]["handleInvoke"]
 >[0];
-type ReactClientWebSocketPayload = {
-  type: "custom";
-  event: string;
-  data: {
-    id: string;
-    payload: ReactClientInvokePayload;
-  };
+type ReactClientWebSocketInvoke = {
+  id: string;
+  payload: ReactClientInvokePayload;
 };
 
 function isPlugin(plugin: unknown): plugin is Plugin {
   return !!plugin && typeof plugin === "object" && "name" in plugin;
 }
 
-function hasPlugin(plugins: UserConfig["plugins"], pluginName: string): boolean {
+function hasPlugin(
+  plugins: UserConfig["plugins"],
+  pluginName: string,
+): boolean {
   for (const plugin of plugins ?? []) {
     if (Array.isArray(plugin)) {
       if (hasPlugin(plugin, pluginName)) return true;
@@ -76,24 +70,19 @@ export function vitestPluginRSC(): Plugin[] {
           }
 
           socket.on("message", async (raw) => {
-            const payload = parseWebSocketPayload(raw);
-            if (
-              payload?.type !== "custom" ||
-              payload.event !== reactClientWebSocketInvokeEvent
-            ) {
-              return;
-            }
+            const invoke = parseWebSocketInvoke(raw);
+            if (!invoke) return;
 
             const result = await server.environments[
               "react_client"
-            ]!.hot.handleInvoke(payload.data.payload);
+            ]!.hot.handleInvoke(invoke.payload);
 
             socket.send(
               JSON.stringify({
                 type: "custom",
                 event: reactClientWebSocketInvokeResultEvent,
                 data: {
-                  id: payload.data.id,
+                  id: invoke.id,
                   result,
                 },
               }),
@@ -101,7 +90,7 @@ export function vitestPluginRSC(): Plugin[] {
           });
         });
 
-        server.middlewares.use(async (req, res, next) => {
+        server.middlewares.use((req, res, next) => {
           const url = new URL(req.url ?? "/", "https://any.local");
           if (url.pathname === reactClientWebSocketInfoPath) {
             res.setHeader("Content-Type", "application/json");
@@ -109,15 +98,6 @@ export function vitestPluginRSC(): Plugin[] {
             return;
           }
 
-          if (url.pathname === reactClientInvokePath) {
-            const payload = JSON.parse(url.searchParams.get("data")!);
-            const result =
-              await server.environments["react_client"]!.hot.handleInvoke(
-                payload,
-              );
-            res.end(JSON.stringify(result));
-            return;
-          }
           next();
         });
       },
@@ -193,28 +173,34 @@ export function vitestPluginRSC(): Plugin[] {
   ];
 }
 
-function parseWebSocketPayload(raw: unknown) {
+function parseWebSocketInvoke(
+  raw: unknown,
+): ReactClientWebSocketInvoke | undefined {
   try {
-    const payload = JSON.parse(String(raw)) as ReactClientWebSocketPayload;
+    const message = JSON.parse(String(raw)) as {
+      type?: string;
+      event?: string;
+      data?: Partial<ReactClientWebSocketInvoke>;
+    };
     if (
-      payload?.type !== "custom" ||
-      typeof payload.event !== "string" ||
-      typeof payload.data?.id !== "string" ||
-      !payload.data.payload
+      message.type !== "custom" ||
+      message.event !== reactClientWebSocketInvokeEvent ||
+      typeof message.data?.id !== "string" ||
+      !message.data.payload
     ) {
       return undefined;
     }
-    return payload;
+    return {
+      id: message.data.id,
+      payload: message.data.payload,
+    };
   } catch {
     return undefined;
   }
 }
 
 function getReactClientWebSocketInfo(server: ViteDevServer) {
-  const hmr =
-    typeof server.config.server.hmr === "object"
-      ? server.config.server.hmr
-      : undefined;
+  const hmr = getHmrOptions(server);
 
   return {
     token: server.config.webSocketToken,
@@ -227,10 +213,7 @@ function getReactClientWebSocketInfo(server: ViteDevServer) {
 }
 
 function getWebSocketPath(server: ViteDevServer) {
-  const hmr =
-    typeof server.config.server.hmr === "object"
-      ? server.config.server.hmr
-      : undefined;
+  const hmr = getHmrOptions(server);
 
   if (!hmr?.path) {
     return server.config.base;
@@ -240,4 +223,10 @@ function getWebSocketPath(server: ViteDevServer) {
     /^\//,
     "",
   )}`;
+}
+
+function getHmrOptions(server: ViteDevServer) {
+  return typeof server.config.server.hmr === "object"
+    ? server.config.server.hmr
+    : undefined;
 }

--- a/packages/vitest-plugin-rsc/src/utilts.ts
+++ b/packages/vitest-plugin-rsc/src/utilts.ts
@@ -4,7 +4,6 @@ import {
   type ModuleRunnerTransport,
 } from "vite/module-runner";
 
-const reactClientInvokePath = "/@vite/invoke-react-client";
 const reactClientWebSocketInfoPath = "/@vite/react-client-runner-websocket";
 const reactClientWebSocketQuery = "vitest-plugin-rsc-react-client";
 const reactClientWebSocketInvokeEvent = "vitest-plugin-rsc:react-client:invoke";
@@ -26,37 +25,32 @@ type WebSocketInfo = {
   path: string;
   timeout: number;
 };
+type PendingInvoke = {
+  resolve: (result: InvokeResult) => void;
+  reject: (error: unknown) => void;
+  timeoutId: ReturnType<typeof setTimeout>;
+};
+type InvokeResultMessage = {
+  type?: string;
+  event?: string;
+  data?: {
+    id?: string;
+    result?: InvokeResult;
+  };
+};
 
 let webSocket: WebSocket | undefined;
 let webSocketPromise: Promise<WebSocket> | undefined;
 let webSocketInfoPromise: Promise<WebSocketInfo> | undefined;
-let webSocketUnavailable = false;
 let nextInvokeId = 0;
 
-const pendingInvokes = new Map<
-  string,
-  {
-    resolve: (result: InvokeResult) => void;
-    reject: (error: unknown) => void;
-    timeoutId: ReturnType<typeof setTimeout>;
-  }
->();
+const pendingInvokes = new Map<string, PendingInvoke>();
 
 const runner = new ModuleRunner(
   {
     sourcemapInterceptor: false,
     transport: {
-      invoke: async (payload) => {
-        if (!webSocketUnavailable && typeof WebSocket !== "undefined") {
-          try {
-            return await invokeReactClientOverWebSocket(payload);
-          } catch {
-            webSocketUnavailable = true;
-          }
-        }
-
-        return invokeReactClientOverHttp(payload);
-      },
+      invoke: invokeReactClient,
     },
     hmr: false,
   },
@@ -65,17 +59,7 @@ const runner = new ModuleRunner(
 
 export const importReactClient = runner.import.bind(runner);
 
-async function invokeReactClientOverHttp(payload: InvokePayload) {
-  const response = await fetch(
-    `${reactClientInvokePath}?` +
-      new URLSearchParams({
-        data: JSON.stringify(payload),
-      }),
-  );
-  return response.json() as Promise<InvokeResult>;
-}
-
-async function invokeReactClientOverWebSocket(payload: InvokePayload) {
+async function invokeReactClient(payload: InvokePayload) {
   const socket = await getReactClientWebSocket();
   const info = await getWebSocketInfo();
   const id = String(++nextInvokeId);
@@ -108,91 +92,90 @@ async function getReactClientWebSocket() {
     return webSocket;
   }
 
-  if (webSocketPromise) {
-    return webSocketPromise;
-  }
-
-  webSocketPromise = (async () => {
-    const info = await getWebSocketInfo();
-    const socket = new WebSocket(createWebSocketUrl(info), "vite-hmr");
-
-    socket.addEventListener("message", handleWebSocketMessage);
-    socket.addEventListener("close", () => {
-      if (webSocket === socket) {
-        webSocket = undefined;
-      }
-      rejectPendingInvokes(
-        new Error("React client websocket connection closed"),
-      );
-    });
-
-    await new Promise<void>((resolve, reject) => {
-      const cleanup = () => {
-        socket.removeEventListener("open", handleOpen);
-        socket.removeEventListener("error", handleError);
-        socket.removeEventListener("close", handleClose);
-      };
-      const handleOpen = () => {
-        cleanup();
-        resolve();
-      };
-      const handleError = () => {
-        cleanup();
-        reject(new Error("React client websocket connection failed"));
-      };
-      const handleClose = () => {
-        cleanup();
-        reject(new Error("React client websocket closed before opening"));
-      };
-
-      socket.addEventListener("open", handleOpen);
-      socket.addEventListener("error", handleError);
-      socket.addEventListener("close", handleClose);
-    });
-
-    webSocket = socket;
-    return socket;
-  })().finally(() => {
+  webSocketPromise ??= openReactClientWebSocket().finally(() => {
     webSocketPromise = undefined;
   });
-
   return webSocketPromise;
 }
 
+async function openReactClientWebSocket() {
+  const info = await getWebSocketInfo();
+  const socket = new WebSocket(createWebSocketUrl(info), "vite-hmr");
+
+  socket.addEventListener("message", handleWebSocketMessage);
+  socket.addEventListener("close", () => {
+    if (webSocket === socket) {
+      webSocket = undefined;
+    }
+    rejectPendingInvokes(new Error("React client websocket connection closed"));
+  });
+
+  await waitForWebSocketOpen(socket);
+  webSocket = socket;
+  return socket;
+}
+
+function waitForWebSocketOpen(socket: WebSocket) {
+  return new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      socket.removeEventListener("open", handleOpen);
+      socket.removeEventListener("error", handleError);
+      socket.removeEventListener("close", handleClose);
+    };
+    const handleOpen = () => {
+      cleanup();
+      resolve();
+    };
+    const handleError = () => {
+      cleanup();
+      reject(new Error("React client websocket connection failed"));
+    };
+    const handleClose = () => {
+      cleanup();
+      reject(new Error("React client websocket closed before opening"));
+    };
+
+    socket.addEventListener("open", handleOpen);
+    socket.addEventListener("error", handleError);
+    socket.addEventListener("close", handleClose);
+  });
+}
+
 function handleWebSocketMessage(event: MessageEvent) {
-  if (typeof event.data !== "string") {
-    return;
-  }
+  const result = parseInvokeResultMessage(event.data);
+  if (!result) return;
 
-  let payload:
-    | {
-        type: "custom";
-        event: string;
-        data: { id: string; result: InvokeResult };
-      }
-    | undefined;
-
-  try {
-    payload = JSON.parse(event.data);
-  } catch {
-    return;
-  }
-
-  if (
-    payload?.type !== "custom" ||
-    payload.event !== reactClientWebSocketInvokeResultEvent
-  ) {
-    return;
-  }
-
-  const pending = pendingInvokes.get(payload.data.id);
+  const pending = pendingInvokes.get(result.id);
   if (!pending) {
     return;
   }
 
   clearTimeout(pending.timeoutId);
-  pendingInvokes.delete(payload.data.id);
-  pending.resolve(payload.data.result);
+  pendingInvokes.delete(result.id);
+  pending.resolve(result.result);
+}
+
+function parseInvokeResultMessage(raw: unknown) {
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+
+  try {
+    const message = JSON.parse(raw) as InvokeResultMessage;
+    if (
+      message.type !== "custom" ||
+      message.event !== reactClientWebSocketInvokeResultEvent ||
+      typeof message.data?.id !== "string"
+    ) {
+      return undefined;
+    }
+    return {
+      id: message.data.id,
+      result: message.data.result as InvokeResult,
+    };
+  } catch {
+    return undefined;
+  }
 }
 
 function rejectPendingInvokes(error: unknown) {


### PR DESCRIPTION
## What changed

- Replace the plugin-name flattening helper with an early-return recursive lookup.
- Remove the Vite-version-specific optimizer platform helper; the React client environment already runs as a client consumer on Vite 8.
- Keep the websocket transport, post optimizer plugin, dependency discovery behavior, and pre-transform behavior from PR #7.

## Validation

- `pnpm --filter vitest-plugin-rsc test -- --run`
- Mirrored the current `epic-rsc-stack` app state into an isolated worktree and compared `bun vitest run`:
  - baseline PR plugin: 13.69s Vitest duration, 14.43s real
  - simplified plugin: 13.41s Vitest duration, 14.15s real
  - simplified plugin warm run: 12.84s Vitest duration, 13.56s real