### PR TITLE
feat: discover React client optimizer entries

### DIFF
--- a/packages/vitest-plugin-rsc/src/index.test.ts
+++ b/packages/vitest-plugin-rsc/src/index.test.ts
@@ -1,0 +1,178 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, expect, test } from "vitest";
+import { resolveConfig, type Plugin, type UserConfig } from "vite";
+import { vitestPluginRSC } from "./index";
+
+let fixtureRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(fixtureRoots.map((root) => rm(root, { recursive: true, force: true })));
+  fixtureRoots = [];
+});
+
+test("discovers use client files as React client optimizer entries", async () => {
+  const root = await createFixture({
+    "src/client.tsx": `
+      // Comments may appear before directive prologues.
+      "use client";
+      import { useState } from "react";
+      export function Client() {
+        return useState(null);
+      }
+    `,
+    "src/nested/single-quote.tsx": `
+      'use client'
+      export const value = 1;
+    `,
+    "src/server.tsx": `
+      import { Client } from "./client";
+      export function Server() {
+        return <Client />;
+      }
+    `,
+    "src/not-a-directive.tsx": `
+      import "server-only";
+      "use client";
+    `,
+  });
+
+  const config = await resolveRscConfig(root);
+
+  expect(config.environments.react_client!.optimizeDeps.entries).toEqual([
+    "src/client.tsx",
+    "src/nested/single-quote.tsx",
+  ]);
+});
+
+test("falls back to source globs when no use client entries are found", async () => {
+  const root = await createFixture({
+    "src/server.tsx": `
+      export function Server() {
+        return null;
+      }
+    `,
+  });
+
+  const config = await resolveRscConfig(root);
+
+  expect(config.environments.react_client!.optimizeDeps.entries).toEqual([
+    "src/**/*.{js,jsx,ts,tsx}",
+    "app/**/*.{js,jsx,ts,tsx}",
+    "components/**/*.{js,jsx,ts,tsx}",
+  ]);
+});
+
+test("keeps user-provided React client optimizer entries", async () => {
+  const root = await createFixture({
+    "src/client.tsx": `
+      "use client";
+      export const value = 1;
+    `,
+  });
+
+  const config = await resolveRscConfig(root, {
+    environments: {
+      react_client: {
+        optimizeDeps: {
+          entries: ["custom-client-entry.tsx"],
+        },
+      },
+    },
+  });
+
+  expect(config.environments.react_client!.optimizeDeps.entries).toEqual([
+    "custom-client-entry.tsx",
+  ]);
+});
+
+test("detects Vitest browser config before browser plugins are injected", async () => {
+  const root = await createFixture({
+    "src/client.tsx": `
+      "use client";
+      export const value = 1;
+    `,
+  });
+
+  const config = await resolveRscConfig(
+    root,
+    {
+      test: {
+        browser: {
+          enabled: true,
+        },
+      },
+    } as UserConfig,
+    false,
+  );
+
+  expect(config.environments.react_client!.optimizeDeps.entries).toEqual(["src/client.tsx"]);
+});
+
+test("disables client optimizers outside Vitest browser mode", async () => {
+  const root = await createFixture({
+    "src/client.tsx": `
+      "use client";
+      export const value = 1;
+    `,
+  });
+
+  const config = await resolveRscConfig(root, {}, false);
+
+  expect(config.environments.client!.optimizeDeps).toMatchObject({
+    noDiscovery: true,
+    include: [],
+    entries: [],
+  });
+  expect(config.environments.react_client!.optimizeDeps).toMatchObject({
+    noDiscovery: true,
+    include: [],
+    entries: [],
+  });
+});
+
+async function resolveRscConfig(
+  root: string,
+  inlineConfig: UserConfig = {},
+  includeBrowserPlugin = true,
+) {
+  return resolveConfig(
+    {
+      ...inlineConfig,
+      configFile: false,
+      root,
+      logLevel: "silent",
+      plugins: [
+        vitestPluginRSC(),
+        ...(includeBrowserPlugin ? [vitestBrowserPlugin()] : []),
+        ...(inlineConfig.plugins ? [inlineConfig.plugins] : []),
+      ],
+      server: {
+        middlewareMode: true,
+        ws: false,
+        ...inlineConfig.server,
+      },
+    },
+    "serve",
+  );
+}
+
+function vitestBrowserPlugin(): Plugin {
+  return { name: "vitest:browser" };
+}
+
+async function createFixture(files: Record<string, string>) {
+  const root = await mkdtemp(path.join(tmpdir(), "vitest-plugin-rsc-"));
+  fixtureRoots.push(root);
+
+  await Promise.all(
+    Object.entries(files).map(async ([file, contents]) => {
+      const absolutePath = path.join(root, file);
+      await mkdir(path.dirname(absolutePath), { recursive: true });
+      await writeFile(absolutePath, contents);
+    }),
+  );
+
+  return root;
+}

--- a/packages/vitest-plugin-rsc/src/index.ts
+++ b/packages/vitest-plugin-rsc/src/index.ts
@@ -1,11 +1,32 @@
-import { type Plugin } from "vite";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { type Plugin, type PluginOption, type UserConfig } from "vite";
 import { vitePluginRscMinimal } from "@vitejs/plugin-rsc/plugin";
+
+const reactClientEnvironmentName = "react_client";
+
+const reactClientOptimizeDepsFallbackEntries = [
+  "src/**/*.{js,jsx,ts,tsx}",
+  "app/**/*.{js,jsx,ts,tsx}",
+  "components/**/*.{js,jsx,ts,tsx}",
+];
+
+const reactClientEntryRoots = ["src", "app", "components"];
+const reactClientEntryExtensions = new Set([".js", ".jsx", ".ts", ".tsx"]);
+const ignoredEntryDirectories = new Set([
+  ".git",
+  ".next",
+  "coverage",
+  "dist",
+  "node_modules",
+  "out",
+]);
 
 export function vitestPluginRSC(): Plugin[] {
   return [
     ...vitePluginRscMinimal({
       environment: {
-        browser: "react_client",
+        browser: reactClientEnvironmentName,
         rsc: "client",
       },
     }),
@@ -48,7 +69,7 @@ export function vitestPluginRSC(): Plugin[] {
                 exclude: ["vite", "vitest-plugin-rsc", "@vitejs/plugin-rsc"],
               },
             },
-            react_client: {
+            [reactClientEnvironmentName]: {
               keepProcessEnv: false,
               resolve: {
                 conditions: ["browser"],
@@ -63,6 +84,7 @@ export function vitestPluginRSC(): Plugin[] {
                   "react/jsx-dev-runtime",
                   "@vitejs/plugin-rsc/vendor/react-server-dom/client.browser",
                 ],
+                noDiscovery: false,
                 exclude: ["vitest-plugin-rsc", "@vitejs/plugin-rsc"],
                 esbuildOptions: {
                   platform: "browser",
@@ -73,5 +95,223 @@ export function vitestPluginRSC(): Plugin[] {
         };
       },
     },
+    {
+      name: "rsc:react-client-optimizer",
+      config: {
+        order: "post",
+        async handler(config) {
+          if (!isVitestBrowserServer(config)) {
+            disableOptimizer(config, "client");
+            disableOptimizer(config, reactClientEnvironmentName);
+            return;
+          }
+
+          const reactClient = ((config.environments ??= {})[reactClientEnvironmentName] ??= {});
+
+          const optimizeDeps = (reactClient.optimizeDeps ??= {});
+          optimizeDeps.noDiscovery = false;
+          optimizeDeps.entries ??=
+            (await findReactClientEntries(config.root)) ?? reactClientOptimizeDepsFallbackEntries;
+        },
+      },
+    },
   ];
+}
+
+function isPlugin(plugin: PluginOption): plugin is Plugin {
+  return !!plugin && typeof plugin === "object" && "name" in plugin;
+}
+
+function flattenPluginNames(plugins: PluginOption[] | undefined): string[] {
+  const names: string[] = [];
+
+  for (const plugin of plugins ?? []) {
+    if (Array.isArray(plugin)) {
+      names.push(...flattenPluginNames(plugin));
+    } else if (isPlugin(plugin)) {
+      names.push(plugin.name);
+    }
+  }
+
+  return names;
+}
+
+function isVitestBrowserServer(config: UserConfig): boolean {
+  return (
+    isVitestBrowserEnabled(config) || flattenPluginNames(config.plugins).includes("vitest:browser")
+  );
+}
+
+function isVitestBrowserEnabled(config: UserConfig): boolean {
+  const browser = (
+    config as UserConfig & {
+      test?: { browser?: boolean | { enabled?: boolean } };
+    }
+  ).test?.browser;
+
+  if (typeof browser === "boolean") {
+    return browser;
+  }
+
+  return browser?.enabled === true;
+}
+
+function disableOptimizer(config: UserConfig, environmentName: string): void {
+  const environment = (config.environments ??= {})[environmentName];
+  if (!environment) return;
+
+  const optimizeDeps = (environment.optimizeDeps ??= {});
+  optimizeDeps.noDiscovery = true;
+  optimizeDeps.include = [];
+  optimizeDeps.entries = [];
+}
+
+async function findReactClientEntries(root = process.cwd()) {
+  const entries: string[] = [];
+
+  for (const entryRoot of reactClientEntryRoots) {
+    const absoluteEntryRoot = path.resolve(root, entryRoot);
+    if (!(await isDirectory(absoluteEntryRoot))) {
+      continue;
+    }
+
+    for await (const file of walkFiles(absoluteEntryRoot)) {
+      if (await hasUseClientDirective(file)) {
+        entries.push(toRootRelativePath(root, file));
+      }
+    }
+  }
+
+  entries.sort();
+  return entries.length ? entries : undefined;
+}
+
+async function isDirectory(directory: string) {
+  try {
+    return (await fs.stat(directory)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function* walkFiles(directory: string): AsyncGenerator<string> {
+  for (const entry of await fs.readdir(directory, { withFileTypes: true })) {
+    if (ignoredEntryDirectories.has(entry.name)) {
+      continue;
+    }
+
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkFiles(absolutePath);
+    } else if (reactClientEntryExtensions.has(path.extname(entry.name))) {
+      yield absolutePath;
+    }
+  }
+}
+
+async function hasUseClientDirective(file: string) {
+  return scanDirectivePrologue(await fs.readFile(file, "utf8")).includes("use client");
+}
+
+function scanDirectivePrologue(source: string) {
+  const directives: string[] = [];
+  let index = source.charCodeAt(0) === 0xfeff ? 1 : 0;
+
+  while (index < source.length) {
+    index = skipWhitespaceAndComments(source, index).index;
+
+    const quote = source[index];
+    if (quote !== '"' && quote !== "'") {
+      break;
+    }
+
+    const parsed = readStringLiteral(source, index, quote);
+    if (!parsed) {
+      break;
+    }
+
+    const afterLiteral = skipWhitespaceAndComments(source, parsed.end);
+    if (source[afterLiteral.index] === ";") {
+      index = afterLiteral.index + 1;
+    } else if (!afterLiteral.hasLineTerminator && afterLiteral.index < source.length) {
+      break;
+    } else {
+      index = afterLiteral.index;
+    }
+
+    directives.push(parsed.value);
+  }
+
+  return directives;
+}
+
+function skipWhitespaceAndComments(source: string, index: number) {
+  let hasLineTerminator = false;
+
+  while (index < source.length) {
+    const char = source[index];
+
+    if (char === " " || char === "\t") {
+      index += 1;
+      continue;
+    }
+
+    if (char === "\n" || char === "\r") {
+      hasLineTerminator = true;
+      index += 1;
+      continue;
+    }
+
+    if (source.startsWith("//", index)) {
+      const lineEnd = source.indexOf("\n", index + 2);
+      hasLineTerminator = true;
+      index = lineEnd === -1 ? source.length : lineEnd + 1;
+      continue;
+    }
+
+    if (source.startsWith("/*", index)) {
+      const commentEnd = source.indexOf("*/", index + 2);
+      const comment = source.slice(index, commentEnd === -1 ? undefined : commentEnd);
+      hasLineTerminator ||= comment.includes("\n") || comment.includes("\r") || commentEnd === -1;
+      index = commentEnd === -1 ? source.length : commentEnd + 2;
+      continue;
+    }
+
+    break;
+  }
+
+  return { index, hasLineTerminator };
+}
+
+function readStringLiteral(source: string, start: number, quote: string) {
+  let value = "";
+
+  for (let index = start + 1; index < source.length; index += 1) {
+    const char = source[index];
+
+    if (char === quote) {
+      return { value, end: index + 1 };
+    }
+
+    if (char === "\\") {
+      if (index + 1 >= source.length) {
+        break;
+      }
+      value += source[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (char === "\n" || char === "\r") {
+      break;
+    }
+
+    value += char;
+  }
+
+  return undefined;
+}
+
+function toRootRelativePath(root: string, file: string) {
+  return path.relative(root, file).replaceAll(path.sep, "/");
 }


### PR DESCRIPTION
## Summary
- Discover likely React Client Component files by scanning source roots for directive-prologue `use client` and use those files as `react_client.optimizeDeps.entries`.
- Preserve user-provided React client optimizer entries, fall back to conservative source globs when no directives are found, and disable client optimizer work outside Vitest browser mode.
- Keep this PR scoped to optimizer/discovery only; the `consumer: \"client\"` environment switch was tested separately and remains coupled to later runtime/transport work because it breaks current setup-module loading.

## Test plan
- `pnpm build`
- `pnpm tsgo`
- `pnpm lint:ci`
- `pnpm test`
- `pnpm format:check`
- `pnpm --filter vitest-plugin-rsc test:run -- src/index.test.ts`
- Baseline comparison on clean `origin/main`: `pnpm --filter ./playground/rsc-vitest-demo test:run -- src/client-counter/client.test.tsx` and `pnpm --filter ./playground/nextjs-notes-demo test:run`

## Research notes
- Vite optimizer entry discovery uses `optimizeDeps.entries` instead of HTML/build input when provided; non-client consumers default `noDiscovery` to true, so this PR explicitly enables discovery only for the React client environment under Vitest browser mode.
- Vite Environment API docs mark `optimizeDeps` as per-environment and not generally inherited; Vitest browser/module-runner docs confirm setup/import execution depends on Vite's module runner path.
- Local PR #8/WebSocket branch source had an optimizer post-plugin shape, but this PR intentionally excludes WebSocket transport and the `consumer: \"client\"` switch.

## Perf notes
- Cold-start intent: reduce React client optimizer churn by scanning exact `use client` entries before Vite's dependency crawl, with fallback globs only when no directives are found.
- Full perf suite was not run here because the perf workflow is separate; playground tests show the optimizer re-runs successfully for both demos.