### PR TITLE
feat: add WebSocket client transport

### DIFF
--- a/packages/vitest-plugin-rsc/package.json
+++ b/packages/vitest-plugin-rsc/package.json
@@ -52,13 +52,15 @@
   "dependencies": {
     "@vitejs/plugin-rsc": "0.5.24",
     "@vitest/expect": "5.0.0-beta.2",
-    "@vitest/spy": "5.0.0-beta.2"
+    "@vitest/spy": "5.0.0-beta.2",
+    "ws": "^8.20.0"
   },
   "devDependencies": {
     "@types/estree": "^1.0.8",
     "@types/node": "^24.12.3",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
+    "@types/ws": "^8.18.1",
     "next": "^15.4.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/packages/vitest-plugin-rsc/src/index.ts
+++ b/packages/vitest-plugin-rsc/src/index.ts
@@ -1,7 +1,17 @@
 import { type Plugin } from "vite";
 import { vitePluginRscMinimal } from "@vitejs/plugin-rsc/plugin";
+import {
+  REACT_CLIENT_WS_CONFIG_ID,
+  REACT_CLIENT_WS_CONFIG_RESOLVED_ID,
+} from "./react-client-websocket";
+import {
+  createReactClientWebSocketConfig,
+  installReactClientWebSocketBridge,
+} from "./react-client-websocket-server";
 
 export function vitestPluginRSC(): Plugin[] {
+  let websocketConfig: string | undefined;
+
   return [
     ...vitePluginRscMinimal({
       environment: {
@@ -11,17 +21,26 @@ export function vitestPluginRSC(): Plugin[] {
     }),
     {
       name: "rsc:run-in-browser",
+      configResolved(config) {
+        websocketConfig = JSON.stringify(createReactClientWebSocketConfig(config));
+      },
       configureServer(server) {
-        server.middlewares.use(async (req, res, next) => {
-          const url = new URL(req.url ?? "/", "https://any.local");
-          if (url.pathname === "/@vite/invoke-react-client") {
-            const payload = JSON.parse(url.searchParams.get("data")!);
-            const result = await server.environments["react_client"]!.hot.handleInvoke(payload);
-            res.end(JSON.stringify(result));
-            return;
+        installReactClientWebSocketBridge(server);
+      },
+      resolveId(id) {
+        if (id === REACT_CLIENT_WS_CONFIG_ID) {
+          return REACT_CLIENT_WS_CONFIG_RESOLVED_ID;
+        }
+      },
+      load(id) {
+        if (id === REACT_CLIENT_WS_CONFIG_RESOLVED_ID) {
+          if (!websocketConfig) {
+            throw new Error(
+              "React client WebSocket config was requested before Vite config resolved.",
+            );
           }
-          next();
-        });
+          return `export default ${websocketConfig};`;
+        }
       },
       hotUpdate(ctx) {
         // TODO find out how to do HMR

--- a/packages/vitest-plugin-rsc/src/react-client-websocket-server.ts
+++ b/packages/vitest-plugin-rsc/src/react-client-websocket-server.ts
@@ -1,0 +1,203 @@
+import { timingSafeEqual } from "node:crypto";
+import path from "node:path";
+import type { IncomingMessage } from "node:http";
+import type { Duplex } from "node:stream";
+import type { HotPayload, ResolvedConfig, ViteDevServer } from "vite";
+import type { RawData, WebSocket } from "ws";
+import { WebSocketServer } from "ws";
+import {
+  REACT_CLIENT_WS_INVOKE_REQUEST,
+  REACT_CLIENT_WS_INVOKE_RESPONSE,
+  REACT_CLIENT_WS_PROTOCOL,
+  type ReactClientInvokeRequest,
+  type ReactClientInvokeResponse,
+  type ReactClientInvokeResult,
+  type ReactClientWebSocketConfig,
+} from "./react-client-websocket";
+
+type HandleInvoke = (payload: HotPayload) => Promise<ReactClientInvokeResult>;
+
+export function createReactClientWebSocketConfig(
+  config: ResolvedConfig,
+): ReactClientWebSocketConfig {
+  const hmrConfig = typeof config.server.hmr === "object" ? config.server.hmr : undefined;
+  const hasHmrServer = !!hmrConfig?.server;
+  let port = hmrConfig?.clientPort ?? hmrConfig?.port ?? null;
+
+  if (config.server.middlewareMode && !hasHmrServer) {
+    port ??= 24678;
+  }
+
+  return {
+    protocol: hmrConfig?.protocol ?? null,
+    host: hmrConfig?.host ?? null,
+    port,
+    path: createReactClientWebSocketPath(config.base, hmrConfig?.path),
+    token: config.webSocketToken,
+    timeout: hmrConfig?.timeout ?? 30000,
+  };
+}
+
+export function createReactClientWebSocketPath(base: string, hmrPath: string | undefined): string {
+  if (!hmrPath) {
+    return base;
+  }
+
+  return path.posix.join(base, hmrPath);
+}
+
+export function installReactClientWebSocketBridge(server: ViteDevServer): () => void {
+  const httpServer = server.httpServer;
+  if (!httpServer) {
+    return () => {};
+  }
+
+  const wss = new WebSocketServer({ noServer: true });
+  const websocketPath = createReactClientWebSocketConfig(server.config).path;
+
+  const onUpgrade = (request: IncomingMessage, socket: Duplex, head: Buffer) => {
+    if (!request.url) {
+      return;
+    }
+
+    const url = new URL(request.url, "http://localhost");
+    if (url.pathname !== websocketPath || !hasReactClientProtocol(request)) {
+      return;
+    }
+
+    if (!hasValidToken(server.config.webSocketToken, url)) {
+      socket.destroy();
+      return;
+    }
+
+    wss.handleUpgrade(request, socket, head, (ws) => {
+      wss.emit("connection", ws, request);
+    });
+  };
+
+  const close = () => {
+    httpServer.off("upgrade", onUpgrade);
+    for (const client of wss.clients) {
+      client.terminate();
+    }
+    wss.close();
+  };
+
+  httpServer.on("upgrade", onUpgrade);
+  httpServer.once("close", close);
+
+  wss.on("connection", (ws) => {
+    ws.on("message", (raw) => {
+      void handleReactClientWebSocketRawMessage(
+        raw,
+        (payload) => server.environments["react_client"]!.hot.handleInvoke(payload),
+        ws,
+      );
+    });
+  });
+
+  return close;
+}
+
+export async function handleReactClientWebSocketRawMessage(
+  raw: RawData | string,
+  handleInvoke: HandleInvoke,
+  ws: Pick<WebSocket, "close" | "send">,
+): Promise<void> {
+  let request: ReactClientInvokeRequest;
+
+  try {
+    request = parseReactClientInvokeRequest(raw);
+  } catch {
+    ws.close();
+    return;
+  }
+
+  const response: ReactClientInvokeResponse = {
+    type: REACT_CLIENT_WS_INVOKE_RESPONSE,
+    id: request.id,
+    response: await invokeReactClient(handleInvoke, request.payload),
+  };
+
+  ws.send(JSON.stringify(response));
+}
+
+export function parseReactClientInvokeRequest(raw: RawData | string): ReactClientInvokeRequest {
+  const data = typeof raw === "string" ? raw : raw.toString();
+  const parsed: unknown = JSON.parse(data);
+
+  if (!isObject(parsed)) {
+    throw new Error("React client WebSocket received a malformed request.");
+  }
+
+  if (
+    parsed.type !== REACT_CLIENT_WS_INVOKE_REQUEST ||
+    typeof parsed.id !== "string" ||
+    !("payload" in parsed)
+  ) {
+    throw new Error("React client WebSocket received an unexpected request.");
+  }
+
+  return parsed as unknown as ReactClientInvokeRequest;
+}
+
+async function invokeReactClient(
+  handleInvoke: HandleInvoke,
+  payload: HotPayload,
+): Promise<ReactClientInvokeResult> {
+  try {
+    return await handleInvoke(payload);
+  } catch (error) {
+    return { error: serializeError(error) };
+  }
+}
+
+function hasReactClientProtocol(request: IncomingMessage) {
+  const protocol = request.headers["sec-websocket-protocol"];
+  if (!protocol) {
+    return false;
+  }
+
+  return protocol
+    .split(",")
+    .map((value) => value.trim())
+    .includes(REACT_CLIENT_WS_PROTOCOL);
+}
+
+function hasValidToken(expectedToken: string, url: URL) {
+  const token = url.searchParams.get("token");
+  if (!token) {
+    return false;
+  }
+
+  const actual = Buffer.from(token);
+  const expected = Buffer.from(expectedToken);
+
+  return actual.length === expected.length && timingSafeEqual(actual, expected);
+}
+
+function serializeError(error: unknown) {
+  if (error instanceof Error) {
+    const serialized: Record<string, unknown> = {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    };
+
+    for (const key of Object.keys(error)) {
+      serialized[key] = (error as unknown as Record<string, unknown>)[key];
+    }
+
+    return serialized;
+  }
+
+  return {
+    name: "Error",
+    message: String(error),
+    stack: new Error().stack,
+  };
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/packages/vitest-plugin-rsc/src/react-client-websocket.test.ts
+++ b/packages/vitest-plugin-rsc/src/react-client-websocket.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  REACT_CLIENT_WS_INVOKE_REQUEST,
+  REACT_CLIENT_WS_INVOKE_RESPONSE,
+  REACT_CLIENT_WS_PROTOCOL,
+  createReactClientWebSocketInvokeTransport,
+  resolveReactClientWebSocketUrl,
+  type ReactClientWebSocketConfig,
+} from "./react-client-websocket";
+import {
+  createReactClientWebSocketConfig,
+  handleReactClientWebSocketRawMessage,
+} from "./react-client-websocket-server";
+
+const baseConfig: ReactClientWebSocketConfig = {
+  protocol: "ws",
+  host: "localhost",
+  port: 5173,
+  path: "/",
+  token: "token",
+  timeout: 1000,
+};
+
+describe("resolveReactClientWebSocketUrl", () => {
+  it("uses Vite HMR host, clientPort, path, token, and explicit protocol", () => {
+    expect(
+      resolveReactClientWebSocketUrl(
+        {
+          protocol: "wss",
+          host: "hmr.example.test",
+          port: 9443,
+          path: "/base/custom-hmr",
+          token: "secret",
+          timeout: 30000,
+        },
+        { protocol: "http:", hostname: "ignored.test", port: "5173" },
+      ),
+    ).toBe("wss://hmr.example.test:9443/base/custom-hmr?token=secret");
+  });
+
+  it("falls back to the browser location and https WebSocket protocol", () => {
+    expect(
+      resolveReactClientWebSocketUrl(
+        {
+          protocol: null,
+          host: null,
+          port: null,
+          path: "vite-dev",
+          token: "secret",
+          timeout: 30000,
+        },
+        { protocol: "https:", hostname: "app.example.test", port: "4443" },
+      ),
+    ).toBe("wss://app.example.test:4443/vite-dev?token=secret");
+  });
+});
+
+describe("createReactClientWebSocketConfig", () => {
+  it("mirrors Vite HMR URL inputs", () => {
+    const config = createReactClientWebSocketConfig({
+      base: "/app/",
+      webSocketToken: "secret",
+      server: {
+        hmr: {
+          clientPort: 9443,
+          host: "hmr.example.test",
+          path: "ws",
+          protocol: "wss",
+          timeout: 1234,
+        },
+        middlewareMode: false,
+      },
+    } as never);
+
+    expect(config).toEqual({
+      protocol: "wss",
+      host: "hmr.example.test",
+      port: 9443,
+      path: "/app/ws",
+      token: "secret",
+      timeout: 1234,
+    });
+  });
+});
+
+describe("createReactClientWebSocketInvokeTransport", () => {
+  it("matches concurrent invoke responses by id", async () => {
+    const transport = createTransport({ idFactory: createIdFactory(["a", "b"]) });
+
+    const first = transport.invoke!({ type: "custom", event: "first" });
+    const second = transport.invoke!({ type: "custom", event: "second" });
+    const websocket = FakeWebSocket.instances[0]!;
+    websocket.open();
+    await waitForSentMessages(websocket, 2);
+
+    expect(websocket.protocols).toBe(REACT_CLIENT_WS_PROTOCOL);
+    expect(websocket.sent.map((message) => JSON.parse(message))).toEqual(
+      expect.arrayContaining([
+        {
+          type: REACT_CLIENT_WS_INVOKE_REQUEST,
+          id: "a",
+          payload: { type: "custom", event: "first" },
+        },
+        {
+          type: REACT_CLIENT_WS_INVOKE_REQUEST,
+          id: "b",
+          payload: { type: "custom", event: "second" },
+        },
+      ]),
+    );
+    expect(websocket.sent.map((message) => JSON.parse(message))).toHaveLength(2);
+
+    websocket.message(
+      JSON.stringify({
+        type: REACT_CLIENT_WS_INVOKE_RESPONSE,
+        id: "b",
+        response: { result: "second-result" },
+      }),
+    );
+    websocket.message(
+      JSON.stringify({
+        type: REACT_CLIENT_WS_INVOKE_RESPONSE,
+        id: "a",
+        response: { result: "first-result" },
+      }),
+    );
+
+    await expect(first).resolves.toEqual({ result: "first-result" });
+    await expect(second).resolves.toEqual({ result: "second-result" });
+  });
+
+  it("preserves handleInvoke error responses", async () => {
+    const transport = createTransport({ idFactory: createIdFactory(["a"]) });
+    const invoke = transport.invoke!({ type: "custom", event: "error" });
+    const websocket = FakeWebSocket.instances[0]!;
+    websocket.open();
+    await waitForSentMessages(websocket, 1);
+
+    websocket.message(
+      JSON.stringify({
+        type: REACT_CLIENT_WS_INVOKE_RESPONSE,
+        id: "a",
+        response: {
+          error: {
+            name: "RollupError",
+            message: "boom",
+            stack: "stack",
+            plugin: "react-client",
+          },
+        },
+      }),
+    );
+
+    await expect(invoke).resolves.toEqual({
+      error: {
+        name: "RollupError",
+        message: "boom",
+        stack: "stack",
+        plugin: "react-client",
+      },
+    });
+  });
+
+  it("rejects pending invokes when the server closes the socket", async () => {
+    const transport = createTransport({ idFactory: createIdFactory(["a"]) });
+    const invoke = transport.invoke!({ type: "custom", event: "close" });
+    const websocket = FakeWebSocket.instances[0]!;
+    websocket.open();
+    await waitForSentMessages(websocket, 1);
+
+    websocket.close();
+
+    await expect(invoke).rejects.toThrow("closed before the invoke response arrived");
+  });
+
+  it("rejects pending invokes on malformed messages", async () => {
+    const transport = createTransport({ idFactory: createIdFactory(["a"]) });
+    const invoke = transport.invoke!({ type: "custom", event: "malformed" });
+    const websocket = FakeWebSocket.instances[0]!;
+    websocket.open();
+    await waitForSentMessages(websocket, 1);
+
+    websocket.message(JSON.stringify({ type: "not-ours", id: "a", response: { result: null } }));
+
+    await expect(invoke).rejects.toThrow("unexpected message");
+  });
+
+  it("rejects invokes that exceed the configured timeout", async () => {
+    const transport = createTransport({
+      config: { ...baseConfig, timeout: 1 },
+      idFactory: createIdFactory(["a"]),
+    });
+    const invoke = transport.invoke!({ type: "custom", event: "timeout" });
+    const websocket = FakeWebSocket.instances[0]!;
+    const assertion = expect(invoke).rejects.toThrow("timed out after 1ms");
+    websocket.open();
+
+    await assertion;
+  });
+});
+
+describe("handleReactClientWebSocketRawMessage", () => {
+  it("sends the handleInvoke response without changing its error shape", async () => {
+    const ws = {
+      close: vi.fn(),
+      send: vi.fn(),
+    };
+
+    await handleReactClientWebSocketRawMessage(
+      JSON.stringify({
+        type: REACT_CLIENT_WS_INVOKE_REQUEST,
+        id: "1",
+        payload: { type: "custom", event: "vite:invoke" },
+      }),
+      async () => ({
+        error: {
+          name: "TransportError",
+          message: "invokeHandlers is not set",
+          stack: "stack",
+        },
+      }),
+      ws,
+    );
+
+    expect(ws.close).not.toHaveBeenCalled();
+    expect(JSON.parse(ws.send.mock.calls[0]![0])).toEqual({
+      type: REACT_CLIENT_WS_INVOKE_RESPONSE,
+      id: "1",
+      response: {
+        error: {
+          name: "TransportError",
+          message: "invokeHandlers is not set",
+          stack: "stack",
+        },
+      },
+    });
+  });
+});
+
+function createTransport({
+  config = baseConfig,
+  idFactory = createIdFactory(["a"]),
+}: {
+  config?: ReactClientWebSocketConfig;
+  idFactory?: () => string;
+} = {}) {
+  FakeWebSocket.instances.length = 0;
+  return createReactClientWebSocketInvokeTransport(config, {
+    WebSocket: FakeWebSocket,
+    idFactory,
+  });
+}
+
+function createIdFactory(ids: string[]) {
+  let index = 0;
+  return () => ids[index++]!;
+}
+
+async function waitForSentMessages(websocket: FakeWebSocket, count: number) {
+  await expect.poll(() => websocket.sent.length).toBe(count);
+}
+
+interface FakeWebSocketEventMap {
+  open: Event;
+  close: CloseEvent;
+  error: Event;
+  message: MessageEvent;
+}
+
+type Listener = (event: FakeWebSocketEventMap[keyof FakeWebSocketEventMap]) => void;
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+
+  readonly listeners = new Map<string, Listener[]>();
+  readonly sent: string[] = [];
+  readonly url: string;
+  readonly protocols: string | string[];
+  readyState = 0;
+
+  constructor(url: string, protocols: string | string[]) {
+    this.url = url;
+    this.protocols = protocols;
+    FakeWebSocket.instances.push(this);
+  }
+
+  addEventListener<K extends keyof FakeWebSocketEventMap>(
+    type: K,
+    listener: (event: FakeWebSocketEventMap[K]) => void,
+  ) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener as Listener);
+    this.listeners.set(type, listeners);
+  }
+
+  close() {
+    this.readyState = 3;
+    this.emit("close", {} as CloseEvent);
+  }
+
+  open() {
+    this.readyState = 1;
+    this.emit("open", new Event("open"));
+  }
+
+  message(data: string) {
+    this.emit("message", { data } as MessageEvent);
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  private emit<K extends keyof FakeWebSocketEventMap>(type: K, event: FakeWebSocketEventMap[K]) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}

--- a/packages/vitest-plugin-rsc/src/react-client-websocket.ts
+++ b/packages/vitest-plugin-rsc/src/react-client-websocket.ts
@@ -1,0 +1,261 @@
+import type { ModuleRunnerTransport } from "vite/module-runner";
+import type { HotPayload } from "vite";
+
+export const REACT_CLIENT_WS_PROTOCOL = "vitest-rsc-react-client";
+export const REACT_CLIENT_WS_CONFIG_ID = "virtual:vitest-plugin-rsc/react-client-websocket-config";
+export const REACT_CLIENT_WS_CONFIG_RESOLVED_ID = `\0${REACT_CLIENT_WS_CONFIG_ID}`;
+
+export const REACT_CLIENT_WS_INVOKE_REQUEST = "vitest-plugin-rsc:react-client:invoke";
+export const REACT_CLIENT_WS_INVOKE_RESPONSE = "vitest-plugin-rsc:react-client:invoke-response";
+
+export interface ReactClientWebSocketConfig {
+  protocol: string | null;
+  host: string | null;
+  port: number | null;
+  path: string;
+  token: string;
+  timeout: number;
+}
+
+export interface ReactClientWebSocketLocation {
+  protocol: string;
+  hostname: string;
+  port: string;
+}
+
+export type ReactClientInvokeResult = { result: unknown } | { error: unknown };
+
+export interface ReactClientInvokeRequest {
+  type: typeof REACT_CLIENT_WS_INVOKE_REQUEST;
+  id: string;
+  payload: HotPayload;
+}
+
+export interface ReactClientInvokeResponse {
+  type: typeof REACT_CLIENT_WS_INVOKE_RESPONSE;
+  id: string;
+  response: ReactClientInvokeResult;
+}
+
+interface TransportWebSocketEventMap {
+  open: Event;
+  close: CloseEvent;
+  error: Event;
+  message: MessageEvent;
+}
+
+interface TransportWebSocket {
+  readonly readyState: number;
+  addEventListener<K extends keyof TransportWebSocketEventMap>(
+    type: K,
+    listener: (event: TransportWebSocketEventMap[K]) => void,
+    options?: AddEventListenerOptions,
+  ): void;
+  close(): void;
+  send(data: string): void;
+}
+
+interface TransportWebSocketConstructor {
+  new (url: string, protocols: string | string[]): TransportWebSocket;
+}
+
+export interface ReactClientWebSocketTransportOptions {
+  WebSocket?: TransportWebSocketConstructor;
+  idFactory?: () => string;
+}
+
+interface PendingInvoke {
+  resolve: (response: ReactClientInvokeResult) => void;
+  reject: (error: Error) => void;
+  timeoutId: ReturnType<typeof setTimeout> | undefined;
+}
+
+const WEBSOCKET_OPEN = 1;
+
+export function resolveReactClientWebSocketUrl(
+  config: ReactClientWebSocketConfig,
+  location: ReactClientWebSocketLocation = globalThis.location,
+): string {
+  const protocol = config.protocol ?? (location.protocol === "https:" ? "wss" : "ws");
+  const host = config.host ?? location.hostname;
+  const port = config.port ?? (location.port ? Number(location.port) : null);
+  const path = config.path.startsWith("/") ? config.path : `/${config.path}`;
+  const url = new URL(`${protocol}://${host}${port == null ? "" : `:${port}`}${path}`);
+  url.searchParams.set("token", config.token);
+  return url.toString();
+}
+
+export function createReactClientWebSocketInvokeTransport(
+  config: ReactClientWebSocketConfig,
+  options: ReactClientWebSocketTransportOptions = {},
+): Pick<ModuleRunnerTransport, "disconnect" | "invoke"> {
+  const WebSocketConstructor = options.WebSocket ?? globalThis.WebSocket;
+  const idFactory = options.idFactory ?? createIncrementingIdFactory();
+  const pendingInvokes = new Map<string, PendingInvoke>();
+
+  let socket: TransportWebSocket | undefined;
+  let socketPromise: Promise<TransportWebSocket> | undefined;
+
+  function rejectPending(error: Error) {
+    for (const pending of pendingInvokes.values()) {
+      clearTimeout(pending.timeoutId);
+      pending.reject(error);
+    }
+    pendingInvokes.clear();
+  }
+
+  async function getSocket(): Promise<TransportWebSocket> {
+    if (socket?.readyState === WEBSOCKET_OPEN) {
+      return socket;
+    }
+
+    if (socketPromise) {
+      return socketPromise;
+    }
+
+    socketPromise = new Promise<TransportWebSocket>((resolve, reject) => {
+      const nextSocket = new WebSocketConstructor(
+        resolveReactClientWebSocketUrl(config),
+        REACT_CLIENT_WS_PROTOCOL,
+      );
+      socket = nextSocket;
+      let didOpen = nextSocket.readyState === WEBSOCKET_OPEN;
+
+      nextSocket.addEventListener(
+        "open",
+        () => {
+          didOpen = true;
+          resolve(nextSocket);
+        },
+        { once: true },
+      );
+
+      nextSocket.addEventListener(
+        "error",
+        () => {
+          if (!didOpen) {
+            reject(new Error("React client WebSocket failed to connect."));
+          }
+        },
+        { once: true },
+      );
+
+      nextSocket.addEventListener("close", () => {
+        socket = undefined;
+        socketPromise = undefined;
+
+        const error = didOpen
+          ? new Error("React client WebSocket closed before the invoke response arrived.")
+          : new Error("React client WebSocket closed before it opened.");
+
+        if (!didOpen) {
+          reject(error);
+        }
+        rejectPending(error);
+      });
+
+      nextSocket.addEventListener("message", (event) => {
+        let response: ReactClientInvokeResponse;
+        try {
+          response = parseReactClientInvokeResponse(event.data);
+        } catch (error) {
+          rejectPending(error instanceof Error ? error : new Error(String(error)));
+          nextSocket.close();
+          return;
+        }
+
+        const pending = pendingInvokes.get(response.id);
+        if (!pending) {
+          return;
+        }
+
+        clearTimeout(pending.timeoutId);
+        pendingInvokes.delete(response.id);
+        pending.resolve(response.response);
+      });
+
+      if (didOpen) {
+        resolve(nextSocket);
+      }
+    });
+
+    return socketPromise;
+  }
+
+  return {
+    disconnect() {
+      socket?.close();
+      socket = undefined;
+      socketPromise = undefined;
+      rejectPending(new Error("React client WebSocket transport was disconnected."));
+    },
+    async invoke(payload) {
+      const id = idFactory();
+      const request: ReactClientInvokeRequest = {
+        type: REACT_CLIENT_WS_INVOKE_REQUEST,
+        id,
+        payload,
+      };
+
+      const activeSocket = await getSocket();
+
+      return await new Promise<ReactClientInvokeResult>((resolve, reject) => {
+        const timeoutId =
+          config.timeout > 0
+            ? setTimeout(() => {
+                pendingInvokes.delete(id);
+                reject(
+                  new Error(`React client WebSocket invoke timed out after ${config.timeout}ms.`),
+                );
+              }, config.timeout)
+            : undefined;
+
+        timeoutId?.unref?.();
+        pendingInvokes.set(id, { resolve, reject, timeoutId });
+
+        try {
+          activeSocket.send(JSON.stringify(request));
+        } catch (error) {
+          clearTimeout(timeoutId);
+          pendingInvokes.delete(id);
+          reject(error instanceof Error ? error : new Error(String(error)));
+        }
+      });
+    },
+  };
+}
+
+export function parseReactClientInvokeResponse(data: unknown): ReactClientInvokeResponse {
+  if (typeof data !== "string") {
+    throw new Error("React client WebSocket received a non-string message.");
+  }
+
+  const parsed: unknown = JSON.parse(data);
+
+  if (!isObject(parsed)) {
+    throw new Error("React client WebSocket received a malformed message.");
+  }
+
+  if (
+    parsed.type !== REACT_CLIENT_WS_INVOKE_RESPONSE ||
+    typeof parsed.id !== "string" ||
+    !isInvokeResult(parsed.response)
+  ) {
+    throw new Error("React client WebSocket received an unexpected message.");
+  }
+
+  return parsed as unknown as ReactClientInvokeResponse;
+}
+
+function createIncrementingIdFactory() {
+  let id = 0;
+  return () => String(++id);
+}
+
+function isInvokeResult(value: unknown): value is ReactClientInvokeResult {
+  return isObject(value) && ("result" in value || "error" in value);
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/packages/vitest-plugin-rsc/src/utilts.ts
+++ b/packages/vitest-plugin-rsc/src/utilts.ts
@@ -1,19 +1,11 @@
 import { ESModulesEvaluator, ModuleRunner } from "vite/module-runner";
+import websocketConfig from "virtual:vitest-plugin-rsc/react-client-websocket-config";
+import { createReactClientWebSocketInvokeTransport } from "./react-client-websocket";
 
 const runner = new ModuleRunner(
   {
     sourcemapInterceptor: false,
-    transport: {
-      invoke: async (payload) => {
-        const response = await fetch(
-          "/@vite/invoke-react-client?" +
-            new URLSearchParams({
-              data: JSON.stringify(payload),
-            }),
-        );
-        return response.json();
-      },
-    },
+    transport: createReactClientWebSocketInvokeTransport(websocketConfig),
     hmr: false,
   },
   new ESModulesEvaluator(),

--- a/packages/vitest-plugin-rsc/src/virtual.d.ts
+++ b/packages/vitest-plugin-rsc/src/virtual.d.ts
@@ -1,0 +1,6 @@
+declare module "virtual:vitest-plugin-rsc/react-client-websocket-config" {
+  import type { ReactClientWebSocketConfig } from "./react-client-websocket";
+
+  const config: ReactClientWebSocketConfig;
+  export default config;
+}

--- a/playground/rsc-vitest-demo/src/transport/server.test.tsx
+++ b/playground/rsc-vitest-demo/src/transport/server.test.tsx
@@ -1,0 +1,14 @@
+import { screen } from "@testing-library/dom";
+import { userEvent } from "@testing-library/user-event";
+import { expect, test } from "vitest";
+import { renderServer } from "vitest-plugin-rsc/testing-library";
+import { ClientCounter } from "../client-counter/client";
+
+test("renders through the WebSocket React client transport", async () => {
+  const removedHttpFallback = await fetch("/@vite/invoke-react-client?data={}");
+  expect(removedHttpFallback.status).not.toBe(200);
+
+  await renderServer(<ClientCounter />);
+  await userEvent.click(await screen.findByRole("button", { name: "client-counter: 0" }));
+  expect(await screen.findByRole("button", { name: "client-counter: 1" })).toBeVisible();
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         version: 8.0.11(@types/node@24.12.3)(tsx@4.20.3)
       vitest:
         specifier: 5.0.0-beta.2
-        version: 5.0.0-beta.2(@types/node@24.12.3)(vite@8.0.11(@types/node@24.12.3)(tsx@4.20.3))
+        version: 5.0.0-beta.2(@opentelemetry/api@1.9.1)(@types/node@24.12.3)(@vitest/browser-playwright@5.0.0-beta.2)(@vitest/ui@5.0.0-beta.2)(msw@2.10.4(@types/node@24.12.3)(typescript@6.0.3))(vite@8.0.11(@types/node@24.12.3)(tsx@4.20.3))
 
   packages/vitest-plugin-rsc:
     dependencies:
@@ -47,6 +47,9 @@ importers:
       '@vitest/spy':
         specifier: 5.0.0-beta.2
         version: 5.0.0-beta.2
+      ws:
+        specifier: ^8.20.0
+        version: 8.20.0
     devDependencies:
       '@types/estree':
         specifier: ^1.0.8
@@ -60,6 +63,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.6
         version: 19.1.6(@types/react@19.1.8)
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       next:
         specifier: ^15.4.5
         version: 15.4.5(@opentelemetry/api@1.9.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -74,7 +80,7 @@ importers:
         version: 1.0.0
       tsdown:
         specifier: ^0.22.0
-        version: 0.22.0(@typescript/native-preview@7.0.0-dev.20260508.1)(publint@0.3.12)(tsx@4.20.3)(typescript@6.0.3)
+        version: 0.22.0(@typescript/native-preview@7.0.0-dev.20260508.1)(tsx@4.20.3)(typescript@6.0.3)
       vite:
         specifier: ^8.0.11
         version: 8.0.11(@types/node@24.12.3)(tsx@4.20.3)
@@ -1018,10 +1024,6 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
-  '@publint/pack@0.1.2':
-    resolution: {integrity: sha512-S+9ANAvUmjutrshV4jZjaiG8XQyuJIZ8a4utWmN/vW1sgQ9IfBnPndwkmQYw53QmouOIytT874u65HEmu6H5jw==}
-    engines: {node: '>=18'}
-
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
@@ -1272,6 +1274,9 @@ packages:
   '@types/node@24.12.3':
     resolution: {integrity: sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ==}
 
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
   '@types/react-dom@19.1.6':
     resolution: {integrity: sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==}
     peerDependencies:
@@ -1288,6 +1293,9 @@ packages:
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260508.1':
     resolution: {integrity: sha512-/JxBvBLSUK0RR5c+baWcdyI1U5VuVrpXScG0IBm8oxstJ0HuFdj6LjRGqe2YbypKBz2VD2EjifLzEwXMWx6VtQ==}
@@ -1813,10 +1821,6 @@ packages:
   mockdate@3.0.5:
     resolution: {integrity: sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==}
 
-  mri@1.2.0:
-    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
-    engines: {node: '>=4'}
-
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -1900,9 +1904,6 @@ packages:
       oxlint-tsgolint:
         optional: true
 
-  package-manager-detector@1.3.0:
-    resolution: {integrity: sha512-ZsEbbZORsyHuO00lY1kV3/t72yp6Ysay6Pd17ZAlNGuGwmWDLCJxFpRs0IzfXfj1o4icJOkUEioexFHzyPurSQ==}
-
   parse-srcset@1.0.2:
     resolution: {integrity: sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==}
 
@@ -1960,11 +1961,6 @@ packages:
 
   psl@1.15.0:
     resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
-
-  publint@0.3.12:
-    resolution: {integrity: sha512-1w3MMtL9iotBjm1mmXtG3Nk06wnq9UhGNRpQ2j6n1Zq7YAD6gnxMMZMIxlRPAydVjVbjSm+n0lhwqsD1m4LD5w==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2038,10 +2034,6 @@ packages:
     resolution: {integrity: sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
-
-  sade@1.8.1:
-    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
-    engines: {node: '>=6'}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -2243,6 +2235,9 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
   undici@6.21.3:
     resolution: {integrity: sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==}
@@ -2879,9 +2874,6 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@publint/pack@0.1.2':
-    optional: true
-
   '@quansync/fs@1.0.0':
     dependencies:
       quansync: 1.0.0
@@ -3040,6 +3032,10 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/node@25.6.0':
+    dependencies:
+      undici-types: 7.19.2
+
   '@types/react-dom@19.1.6(@types/react@19.1.8)':
     dependencies:
       '@types/react': 19.1.8
@@ -3055,6 +3051,10 @@ snapshots:
   '@types/statuses@2.0.6': {}
 
   '@types/tough-cookie@4.0.5': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.6.0
 
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260508.1':
     optional: true
@@ -3160,14 +3160,6 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.10.4(@types/node@24.12.3)(typescript@6.0.3)
-      vite: 8.0.11(@types/node@24.12.3)(tsx@4.20.3)
-
-  '@vitest/mocker@5.0.0-beta.2(vite@8.0.11(@types/node@24.12.3)(tsx@4.20.3))':
-    dependencies:
-      '@vitest/spy': 5.0.0-beta.2
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
       vite: 8.0.11(@types/node@24.12.3)(tsx@4.20.3)
 
   '@vitest/pretty-format@5.0.0-beta.2':
@@ -3566,9 +3558,6 @@ snapshots:
 
   mockdate@3.0.5: {}
 
-  mri@1.2.0:
-    optional: true
-
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
@@ -3694,9 +3683,6 @@ snapshots:
       '@oxlint/binding-win32-x64-msvc': 1.63.0
       oxlint-tsgolint: 0.22.1
 
-  package-manager-detector@1.3.0:
-    optional: true
-
   parse-srcset@1.0.2: {}
 
   parse5-htmlparser2-tree-adapter@7.1.0:
@@ -3757,14 +3743,6 @@ snapshots:
   psl@1.15.0:
     dependencies:
       punycode: 2.3.1
-
-  publint@0.3.12:
-    dependencies:
-      '@publint/pack': 0.1.2
-      package-manager-detector: 1.3.0
-      picocolors: 1.1.1
-      sade: 1.8.1
-    optional: true
 
   punycode@2.3.1: {}
 
@@ -3853,11 +3831,6 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.0.0-rc.18
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.18
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.18
-
-  sade@1.8.1:
-    dependencies:
-      mri: 1.2.0
-    optional: true
 
   safer-buffer@2.1.2: {}
 
@@ -3988,7 +3961,7 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  tsdown@0.22.0(@typescript/native-preview@7.0.0-dev.20260508.1)(publint@0.3.12)(tsx@4.20.3)(typescript@6.0.3):
+  tsdown@0.22.0(@typescript/native-preview@7.0.0-dev.20260508.1)(tsx@4.20.3)(typescript@6.0.3):
     dependencies:
       ansis: 4.2.0
       cac: 7.0.0
@@ -4006,7 +3979,6 @@ snapshots:
       tree-kill: 1.2.2
       unconfig-core: 7.5.0
     optionalDependencies:
-      publint: 0.3.12
       tsx: 4.20.3
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -4040,6 +4012,8 @@ snapshots:
   uncrypto@0.1.3: {}
 
   undici-types@7.16.0: {}
+
+  undici-types@7.19.2: {}
 
   undici@6.21.3: {}
 
@@ -4103,33 +4077,6 @@ snapshots:
       '@types/node': 24.12.3
       '@vitest/browser-playwright': 5.0.0-beta.2(msw@2.10.4(@types/node@24.12.3)(typescript@6.0.3))(playwright@1.54.1)(vite@8.0.11(@types/node@24.12.3)(tsx@4.20.3))(vitest@5.0.0-beta.2)
       '@vitest/ui': 5.0.0-beta.2(vitest@5.0.0-beta.2)
-    transitivePeerDependencies:
-      - msw
-
-  vitest@5.0.0-beta.2(@types/node@24.12.3)(vite@8.0.11(@types/node@24.12.3)(tsx@4.20.3)):
-    dependencies:
-      '@types/chai': 5.2.2
-      '@vitest/mocker': 5.0.0-beta.2(vite@8.0.11(@types/node@24.12.3)(tsx@4.20.3))
-      '@vitest/pretty-format': 5.0.0-beta.2
-      '@vitest/runner': 5.0.0-beta.2
-      '@vitest/spy': 5.0.0-beta.2
-      '@vitest/utils': 5.0.0-beta.2
-      chai: 6.2.2
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.2
-      tinyglobby: 0.2.16
-      tinyrainbow: 3.1.0
-      vite: 8.0.11(@types/node@24.12.3)(tsx@4.20.3)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 24.12.3
     transitivePeerDependencies:
       - msw
 


### PR DESCRIPTION
## Summary
- Replaces the React client runner HTTP invoke endpoint with a plugin-owned WebSocket invoke transport and removes the `/@vite/invoke-react-client` fallback route.
- Adds a server-side noServer WebSocket bridge using a dedicated `vitest-rsc-react-client` subprotocol, Vite's websocket token, and Vite HMR URL inputs for protocol/host/clientPort/path/base/timeout.
- Covers URL construction, malformed messages, close/timeout handling, concurrent invokes, and handleInvoke error preservation, plus a browser smoke test proving the old HTTP endpoint is gone while RSC rendering still works.

## Research notes
- Vite `ModuleRunner` fetches modules through `transport.invoke('fetchModule', ...)`; Vite's built-in WebSocket transport wraps that as `vite:invoke` RPC traffic.
- Vite's browser client builds its socket from HMR protocol, host, clientPort/port, base/path, timeout, and websocket token, and the server validates browser websocket token query params before upgrade.
- Vitest browser mode uses a separate noServer `WebSocketServer` bridge for browser RPC, which matches this plugin-owned bridge pattern better than sharing the page's Vite HMR channel.

## Test plan
- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm tsgo`
- `pnpm lint:ci`
- `pnpm --filter vitest-plugin-rsc exec vitest run src/react-client-websocket.test.ts`
- `pnpm --filter ./playground/rsc-vitest-demo test:run -- src/transport/server.test.tsx`
- `pnpm test`

## Perf notes
- Perf suite is not available in this worktree yet; no benchmark artifact was added.
- Local browser smoke evidence: the RSC playground browser run passed 10 files / 13 tests in about 3.8-4.0s while exercising the WebSocket transport.