### PR TITLE
test: add performance benchmark suite

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,41 @@
+name: Performance
+
+on:
+  workflow_dispatch:
+    inputs:
+      runs:
+        description: Hyperfine measured runs per scenario
+        required: false
+        default: "3"
+  schedule:
+    - cron: "17 4 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  repo-local:
+    name: Repo-local benchmarks
+    runs-on: ubuntu-latest
+    env:
+      PERF_HYPERFINE_RUNS: ${{ github.event.inputs.runs || '3' }}
+      PERF_OUTPUT_DIR: artifacts/perf/ci
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: sudo apt-get update && sudo apt-get install -y hyperfine
+      - run: pnpm --dir playground/rsc-vitest-demo exec playwright install --with-deps --only-shell chromium
+      - run: pnpm build
+      - run: pnpm perf:ci
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: perf-artifacts
+          path: artifacts/perf/
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 coverage/
+artifacts/perf/
 *.tsbuildinfo
 *.local
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,127 @@
+# Performance Benchmarks
+
+This repo keeps two benchmark layers:
+
+- Repo-local Vitest command benchmarks are the portable baseline. They run in CI, produce JSON artifacts, and cover the fixtures that ship with this repository.
+- `epic-rsc-stack` is the comprehensive real-world acceptance benchmark. Run it locally before merging feature PRs that could affect runtime behavior and before cutting `0.1.0`.
+
+There is also an optional Vitest bench micro layer for render-helper hotspots. It is supporting evidence only; the main acceptance signal is end-to-end Vitest browser command runtime.
+
+The suite is intentionally informational for now. It fails when benchmark commands fail, but it does not enforce timing thresholds or block PRs on small regressions.
+
+## Prerequisites
+
+- Node 24 and pnpm for this repository.
+- Chromium for Vitest browser mode: `pnpm --dir playground/rsc-vitest-demo exec playwright install --with-deps --only-shell chromium`.
+- `hyperfine` on your PATH for whole-command benchmarks.
+- For `epic-rsc-stack`, keep a local checkout available. The perf script prepares an ignored generated copy and installs this repo's packed candidate plugin build into that copy before measuring.
+
+## Repo-Local Benchmarks
+
+Run the portable suite:
+
+```sh
+pnpm perf
+```
+
+This writes ignored artifacts under `artifacts/perf/local`:
+
+- `commands/*.hyperfine.json` for whole-command timings.
+- `commands/summary.md` for a concise command benchmark summary.
+
+The whole-command layer currently covers:
+
+- Cold and warm browser-mode `vitest run` for `playground/rsc-vitest-demo`.
+- A warm focused RSC action, payload, and client-boundary scenario for `playground/rsc-vitest-demo`.
+- Cold and warm focused smoke runs for `playground/nextjs-notes-demo`.
+
+Cold scenarios use `hyperfine --prepare` to clear Vite/Vitest cache directories outside the measured command. Warm scenarios use `hyperfine --warmup` to prime caches before measured runs.
+
+The optional micro layer currently covers:
+
+- Server component rendering through `renderServer`.
+- Client component rendering plus a browser update.
+
+You can tune runs without editing committed files:
+
+```sh
+PERF_HYPERFINE_RUNS=5 pnpm perf:commands
+VITE_PERF_BENCH_TIME_MS=500 VITE_PERF_BENCH_ITERATIONS=20 pnpm perf:micro
+```
+
+## Comparing Branches
+
+Capture `main` first:
+
+```sh
+git switch main
+pnpm install --frozen-lockfile
+pnpm build
+PERF_OUTPUT_DIR=artifacts/perf/main pnpm perf
+```
+
+Then capture the candidate branch:
+
+```sh
+git switch <candidate-branch>
+pnpm install --frozen-lockfile
+pnpm build
+PERF_OUTPUT_DIR=artifacts/perf/candidate pnpm perf
+```
+
+For Vitest bench comparisons, use the saved JSON from `main`:
+
+```sh
+PERF_OUTPUT_DIR=artifacts/perf/candidate \
+  pnpm perf:micro -- --compare artifacts/perf/main/vitest-bench/render.json
+```
+
+For command-level comparisons, compare the two `commands/summary.md` files and keep the raw hyperfine JSON artifacts attached to the PR or CI run.
+
+## Real-World Acceptance: epic-rsc-stack
+
+The epic stack is the primary confidence signal for runtime-sensitive work. The committed scripts do not depend on a machine-specific absolute path. By default they look for `../epic-rsc-stack`; override that with `--app` or `EPIC_RSC_STACK_PATH`.
+
+Before timing, `pnpm perf:epic`:
+
+- Builds `packages/vitest-plugin-rsc`.
+- Packs it with `pnpm pack`.
+- Copies the epic app into an ignored generated workspace under `artifacts/perf`, excluding `.git`, `node_modules`, build/cache outputs, coverage, and `.env*` files.
+- Rewrites only the generated workspace's `package.json` so `vitest-plugin-rsc` points at the local tarball, then runs `bun install --no-cache --ignore-scripts`.
+- Hashes the source package `dist` directory and installed `node_modules/vitest-plugin-rsc/dist` directory, failing if they differ.
+- Clears `.vite` for cold scenarios with `hyperfine --prepare` so the cleanup is outside the measured command.
+
+Run the real-world benchmark:
+
+```sh
+pnpm perf:epic
+```
+
+Or point at another checkout:
+
+```sh
+pnpm perf:epic -- --app ../epic-rsc-stack
+EPIC_RSC_STACK_PATH=../epic-rsc-stack pnpm perf:epic
+```
+
+The epic mode runs cold and warm browser-project Vitest commands in the generated app copy and writes artifacts under `artifacts/perf/local/commands` unless `PERF_OUTPUT_DIR` is set. `epic-preparation.json` is written before timing starts, so failed acceptance runs still record the source app git SHA, generated workspace path, tarball path/hash, installed package metadata, and matching source/installed dist hashes.
+
+If the app has its coverage provider installed, include a warm coverage scenario:
+
+```sh
+pnpm perf:epic -- --coverage
+PERF_EPIC_COVERAGE=1 pnpm perf:epic
+```
+
+For feature PRs and the `0.1.0` release readiness check, report:
+
+- The repo-local `pnpm perf` result and artifact location.
+- The `pnpm perf:epic` result and artifact location.
+- Optional `pnpm perf:micro` or epic coverage evidence when it helps explain a change.
+- Any known environmental caveats, such as a laptop under load or an intentionally small run count.
+
+## CI
+
+The `Performance` workflow is manual via `workflow_dispatch` and scheduled weekly. It installs `hyperfine`, builds the package, runs repo-local benchmarks on Node 24 with pnpm, and uploads `artifacts/perf`.
+
+CI does not run `epic-rsc-stack` because that app is external to this repository. Use the local epic mode as the comprehensive acceptance benchmark before merging runtime-sensitive work.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
     "tsgo": "tsgo --build",
     "build": "pnpm -r --filter='./packages/*' run build",
     "test": "pnpm -r --workspace-concurrency=1 --if-present run test:run",
+    "perf": "pnpm perf:commands",
+    "perf:ci": "pnpm perf",
+    "perf:commands": "node scripts/perf/run-command-benchmarks.ts repo",
+    "perf:micro": "node scripts/perf/run-vitest-bench.ts",
+    "perf:epic": "node scripts/perf/run-command-benchmarks.ts epic",
     "dev": "pnpm -r --parallel --filter='./packages/*' run dev"
   },
   "devDependencies": {

--- a/playground/rsc-vitest-demo/src/perf/render.bench.tsx
+++ b/playground/rsc-vitest-demo/src/perf/render.bench.tsx
@@ -1,0 +1,48 @@
+/// <reference types="vite/client" />
+
+import { screen } from "@testing-library/dom";
+import { userEvent } from "@testing-library/user-event";
+import { bench, describe } from "vitest";
+import { renderServer, cleanup } from "vitest-plugin-rsc/testing-library";
+import { ServerCounter } from "../action/server.tsx";
+import { ClientCounter } from "../client-counter/client.tsx";
+
+const options = {
+  iterations: Number(import.meta.env.VITE_PERF_BENCH_ITERATIONS ?? 10),
+  time: Number(import.meta.env.VITE_PERF_BENCH_TIME_MS ?? 250),
+  warmupIterations: Number(import.meta.env.VITE_PERF_BENCH_WARMUP_ITERATIONS ?? 2),
+  warmupTime: Number(import.meta.env.VITE_PERF_BENCH_WARMUP_TIME_MS ?? 100),
+};
+
+describe("RSC render helpers", () => {
+  bench(
+    "server component render",
+    async () => {
+      await withCleanup(async () => {
+        await renderServer(<ServerCounter />);
+        await screen.findByRole("button", { name: "server-counter: 0" });
+      });
+    },
+    options,
+  );
+
+  bench(
+    "client component render and update",
+    async () => {
+      await withCleanup(async () => {
+        await renderServer(<ClientCounter />);
+        await userEvent.click(await screen.findByRole("button", { name: "client-counter: 0" }));
+        await screen.findByRole("button", { name: "client-counter: 1" });
+      });
+    },
+    options,
+  );
+});
+
+async function withCleanup(callback: () => Promise<void>): Promise<void> {
+  try {
+    await callback();
+  } finally {
+    await cleanup();
+  }
+}

--- a/scripts/perf/run-command-benchmarks.ts
+++ b/scripts/perf/run-command-benchmarks.ts
@@ -1,0 +1,515 @@
+/// <reference types="node" />
+
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { cp, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { parseArgs } from "node:util";
+import {
+  detectPackageRunner,
+  ensureDir,
+  formatSeconds,
+  numberOption,
+  readPackageJson,
+  repoRoot,
+  resolveOutputDir,
+  sanitizeName,
+  writeJson,
+} from "./utils.ts";
+
+type Scenario = {
+  name: string;
+  description: string;
+  cwd: string;
+  command: string[];
+  prepare?: string[];
+  runs: number;
+  warmup: number;
+};
+
+type HyperfineResult = {
+  command: string;
+  mean?: number;
+  stddev?: number;
+  median?: number;
+  min?: number;
+  max?: number;
+};
+
+type EpicPreparation = {
+  sourcePath: string;
+  preparedPath: string;
+  sourceGit: ReturnType<typeof gitMetadata>;
+  tarballPath: string;
+  tarballSha256: string;
+  sourceDistSha256: string;
+  installedDistSha256: string;
+  installedPackageJson: Record<string, unknown>;
+};
+
+async function main(): Promise<void> {
+  const { positionals, values } = parseArgs({
+    args: process.argv.slice(2).filter((arg) => arg !== "--"),
+    allowPositionals: true,
+    options: {
+      app: { type: "string" },
+      coverage: { type: "boolean" },
+      label: { type: "string" },
+      "output-dir": { type: "string" },
+      runs: { type: "string" },
+      "show-output": { type: "boolean" },
+      warmup: { type: "string" },
+      workdir: { type: "string" },
+    },
+  });
+
+  const mode = positionals[0] ?? "repo";
+  if (mode !== "repo" && mode !== "epic") {
+    throw new Error(`Unknown benchmark mode "${mode}". Expected "repo" or "epic".`);
+  }
+
+  const outputDir = resolveOutputDir(values["output-dir"], "commands");
+  const label = values.label ?? process.env.PERF_LABEL ?? mode;
+  const runs = numberOption(values.runs ?? process.env.PERF_HYPERFINE_RUNS, 3);
+  const warmup = numberOption(values.warmup ?? process.env.PERF_HYPERFINE_WARMUP, 1);
+
+  assertHyperfine();
+  await ensureDir(outputDir);
+
+  let epicPreparation: EpicPreparation | undefined;
+  const scenarios =
+    mode === "epic"
+      ? epicScenarios({
+          coverage: values.coverage === true || process.env.PERF_EPIC_COVERAGE === "1",
+          outputDir,
+          runs,
+          warmup,
+        })
+      : repoScenarios(runs, warmup);
+
+  if (mode === "epic") {
+    epicPreparation = await prepareEpicCandidateApp({
+      appPath: resolveEpicSourcePath(values.app),
+      outputRoot: path.dirname(outputDir),
+      workdir: values.workdir,
+    });
+    await writeJson(path.join(outputDir, "epic-preparation.json"), epicPreparation);
+
+    for (const scenario of scenarios) {
+      scenario.cwd = epicPreparation.preparedPath;
+    }
+  }
+
+  const completed: { scenario: Scenario; jsonPath: string; result: HyperfineResult }[] = [];
+  for (const scenario of scenarios) {
+    const jsonPath = path.join(outputDir, `${sanitizeName(scenario.name)}.hyperfine.json`);
+    runHyperfine(scenario, jsonPath, values["show-output"] === true);
+    completed.push({
+      scenario,
+      jsonPath,
+      result: await readHyperfineResult(jsonPath),
+    });
+  }
+
+  await writeJson(path.join(outputDir, "metadata.json"), {
+    label,
+    mode,
+    createdAt: new Date().toISOString(),
+    repo: gitMetadata(repoRoot),
+    epicPreparation,
+    scenarios: scenarios.map(({ name, description, cwd, command, prepare, runs, warmup }) => ({
+      name,
+      description,
+      cwd,
+      command,
+      prepare,
+      runs,
+      warmup,
+    })),
+  });
+  await writeSummary(path.join(outputDir, "summary.md"), label, mode, completed);
+
+  console.log(`Wrote command benchmark artifacts to ${path.relative(repoRoot, outputDir)}`);
+}
+
+function repoScenarios(runs: number, warmup: number): Scenario[] {
+  return [
+    {
+      name: "rsc-vitest-demo:cold:all-tests",
+      description: "Cold browser-mode Vitest run for the core RSC playground.",
+      cwd: repoRoot,
+      command: ["pnpm", "--dir", "playground/rsc-vitest-demo", "exec", "vitest", "run"],
+      prepare: [
+        "node",
+        "-e",
+        "fs.rmSync('playground/rsc-vitest-demo/.vite',{recursive:true,force:true})",
+      ],
+      runs,
+      warmup: 0,
+    },
+    {
+      name: "rsc-vitest-demo:warm:all-tests",
+      description: "Warm browser-mode Vitest run for the core RSC playground.",
+      cwd: repoRoot,
+      command: ["pnpm", "--dir", "playground/rsc-vitest-demo", "exec", "vitest", "run"],
+      runs,
+      warmup,
+    },
+    {
+      name: "rsc-vitest-demo:warm:actions-payload",
+      description: "Warm focused RSC action, payload, and client boundary coverage.",
+      cwd: repoRoot,
+      command: [
+        "pnpm",
+        "--dir",
+        "playground/rsc-vitest-demo",
+        "exec",
+        "vitest",
+        "run",
+        "src/action/server.test.tsx",
+        "src/action-bind/server.test.tsx",
+        "src/action-from-client/client.test.tsx",
+        "src/payload/server.test.tsx",
+      ],
+      runs,
+      warmup,
+    },
+    {
+      name: "nextjs-notes-demo:cold:smoke",
+      description: "Cold focused smoke coverage for the Next.js playground.",
+      cwd: repoRoot,
+      command: [
+        "pnpm",
+        "--dir",
+        "playground/nextjs-notes-demo",
+        "exec",
+        "vitest",
+        "run",
+        "components/auth-button.test.tsx",
+        "components/note-editor.test.tsx",
+      ],
+      prepare: [
+        "node",
+        "-e",
+        "fs.rmSync('playground/nextjs-notes-demo/.vite',{recursive:true,force:true})",
+      ],
+      runs,
+      warmup: 0,
+    },
+    {
+      name: "nextjs-notes-demo:warm:smoke",
+      description: "Warm focused smoke coverage for the Next.js playground.",
+      cwd: repoRoot,
+      command: [
+        "pnpm",
+        "--dir",
+        "playground/nextjs-notes-demo",
+        "exec",
+        "vitest",
+        "run",
+        "components/auth-button.test.tsx",
+        "components/note-editor.test.tsx",
+      ],
+      runs,
+      warmup,
+    },
+  ];
+}
+
+function epicScenarios(options: {
+  coverage: boolean;
+  outputDir: string;
+  runs: number;
+  warmup: number;
+}): Scenario[] {
+  const scenarios: Scenario[] = [
+    {
+      name: "epic-rsc-stack:cold:browser-suite",
+      description: "Cold full browser project run for the real-world acceptance app.",
+      cwd: "",
+      command: ["bun", "vitest", "run", "--project=browser"],
+      prepare: ["node", "-e", "fs.rmSync('.vite',{recursive:true,force:true})"],
+      runs: options.runs,
+      warmup: 0,
+    },
+    {
+      name: "epic-rsc-stack:warm:browser-suite",
+      description: "Warm full browser project run for the real-world acceptance app.",
+      cwd: "",
+      command: ["bun", "vitest", "run", "--project=browser"],
+      runs: options.runs,
+      warmup: options.warmup,
+    },
+  ];
+
+  if (options.coverage) {
+    scenarios.push({
+      name: "epic-rsc-stack:warm:browser-coverage",
+      description: "Warm browser project run with coverage enabled in the real-world app.",
+      cwd: "",
+      command: [
+        "bun",
+        "vitest",
+        "run",
+        "--project=browser",
+        "--coverage",
+        "--coverage.reporter=json-summary",
+        `--coverage.reportsDirectory=${path.join(options.outputDir, "epic-coverage")}`,
+      ],
+      runs: options.runs,
+      warmup: options.warmup,
+    });
+  }
+
+  return scenarios;
+}
+
+function resolveEpicSourcePath(appFlag: string | undefined): string {
+  return path.resolve(
+    appFlag ?? process.env.EPIC_RSC_STACK_PATH ?? path.join(repoRoot, "..", "epic-rsc-stack"),
+  );
+}
+
+async function prepareEpicCandidateApp(options: {
+  appPath: string;
+  outputRoot: string;
+  workdir: string | undefined;
+}): Promise<EpicPreparation> {
+  if (!existsSync(path.join(options.appPath, "package.json"))) {
+    throw new Error(
+      `Cannot find epic-rsc-stack package.json at ${options.appPath}. Pass --app or EPIC_RSC_STACK_PATH.`,
+    );
+  }
+  if ((await detectPackageRunner(options.appPath)) !== "bun") {
+    throw new Error("epic-rsc-stack is expected to use Bun for dependency installation.");
+  }
+
+  const preparedPath = path.resolve(
+    options.workdir ?? path.join(options.outputRoot, "epic-rsc-stack-candidate"),
+  );
+  const packageDir = path.join(options.outputRoot, "packages");
+
+  console.log("Building and packing vitest-plugin-rsc candidate");
+  run("pnpm", ["build"], repoRoot);
+  await rm(packageDir, { recursive: true, force: true });
+  await mkdir(packageDir, { recursive: true });
+  run(
+    "pnpm",
+    ["--dir", "packages/vitest-plugin-rsc", "pack", "--pack-destination", packageDir],
+    repoRoot,
+  );
+
+  const tarballPath = await findOnlyTarball(packageDir);
+
+  console.log(`Preparing epic-rsc-stack candidate workspace at ${preparedPath}`);
+  await rm(preparedPath, { recursive: true, force: true });
+  await cp(options.appPath, preparedPath, {
+    recursive: true,
+    filter: (source) => !isIgnoredEpicCopyPath(options.appPath, source),
+  });
+
+  await pointEpicAtCandidatePackage(preparedPath, tarballPath);
+  run("bun", ["install", "--no-cache", "--ignore-scripts"], preparedPath);
+  await rm(path.join(preparedPath, ".vite"), { recursive: true, force: true });
+
+  const installedPackageJson = await readPackageJson(
+    path.join(preparedPath, "node_modules", "vitest-plugin-rsc"),
+  );
+  const sourceDistSha256 = await hashDirectory(
+    path.join(repoRoot, "packages", "vitest-plugin-rsc", "dist"),
+  );
+  const installedDistSha256 = await hashDirectory(
+    path.join(preparedPath, "node_modules", "vitest-plugin-rsc", "dist"),
+  );
+
+  if (sourceDistSha256 !== installedDistSha256) {
+    throw new Error("Installed epic candidate package dist does not match the packed local build.");
+  }
+
+  return {
+    sourcePath: options.appPath,
+    preparedPath,
+    sourceGit: gitMetadata(options.appPath),
+    tarballPath,
+    tarballSha256: await hashFile(tarballPath),
+    sourceDistSha256,
+    installedDistSha256,
+    installedPackageJson,
+  };
+}
+
+function isIgnoredEpicCopyPath(sourceRoot: string, source: string): boolean {
+  const relative = path.relative(sourceRoot, source);
+  if (!relative) return false;
+  if (relative === ".env" || relative.startsWith(".env.")) return true;
+  const firstSegment = relative.split(path.sep)[0];
+  return new Set([".git", ".next", ".vite", "coverage", "node_modules"]).has(firstSegment);
+}
+
+async function pointEpicAtCandidatePackage(
+  preparedPath: string,
+  tarballPath: string,
+): Promise<void> {
+  const packageJsonPath = path.join(preparedPath, "package.json");
+  const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as {
+    devDependencies?: Record<string, string>;
+  };
+  const devDependencies = packageJson.devDependencies ?? {};
+  const relativeTarball = path.relative(preparedPath, tarballPath).split(path.sep).join("/");
+
+  devDependencies["vitest-plugin-rsc"] = `file:${relativeTarball}`;
+  packageJson.devDependencies = devDependencies;
+
+  await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+}
+
+async function findOnlyTarball(packageDir: string): Promise<string> {
+  const entries = await readdir(packageDir);
+  const tarballs = entries.filter((entry) => entry.endsWith(".tgz"));
+  if (tarballs.length !== 1) {
+    throw new Error(`Expected one packed tarball in ${packageDir}, found ${tarballs.length}.`);
+  }
+  return path.join(packageDir, tarballs[0]);
+}
+
+function assertHyperfine(): void {
+  const result = spawnSync("hyperfine", ["--version"], { encoding: "utf8" });
+  if (result.error) {
+    throw new Error(
+      "hyperfine is required for command benchmarks. Install it with your system package manager, then rerun the perf script.",
+    );
+  }
+}
+
+function runHyperfine(scenario: Scenario, jsonPath: string, showOutput: boolean): void {
+  console.log(`\nBenchmarking ${scenario.name}`);
+  const args = [
+    "--runs",
+    String(scenario.runs),
+    "--warmup",
+    String(scenario.warmup),
+    "--export-json",
+    jsonPath,
+    "--command-name",
+    scenario.name,
+  ];
+
+  if (showOutput) args.push("--show-output");
+  if (scenario.prepare) args.push("--prepare", quoteCommand(scenario.prepare));
+  args.push(quoteCommand(scenario.command));
+
+  run("hyperfine", args, scenario.cwd);
+}
+
+function run(command: string, args: string[], cwd: string): void {
+  const result = spawnSync(command, args, {
+    cwd,
+    stdio: "inherit",
+  });
+
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(" ")} failed with exit code ${result.status}`);
+  }
+}
+
+function quoteCommand(parts: string[]): string {
+  return parts.map(quoteShellArg).join(" ");
+}
+
+function quoteShellArg(value: string): string {
+  if (/^[A-Za-z0-9_/:=.,@%+-]+$/.test(value)) return value;
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+async function readHyperfineResult(jsonPath: string): Promise<HyperfineResult> {
+  const report = JSON.parse(await readFile(jsonPath, "utf8")) as { results?: HyperfineResult[] };
+  const result = report.results?.[0];
+  if (!result) throw new Error(`No hyperfine result found in ${jsonPath}`);
+  return result;
+}
+
+async function writeSummary(
+  summaryPath: string,
+  label: string,
+  mode: string,
+  completed: { scenario: Scenario; jsonPath: string; result: HyperfineResult }[],
+): Promise<void> {
+  const lines = [
+    `# Performance Command Summary`,
+    ``,
+    `Label: ${label}`,
+    `Mode: ${mode}`,
+    `Created: ${new Date().toISOString()}`,
+    ``,
+    `These timings are informational. The suite fails on command errors, not on timing deltas.`,
+    ``,
+  ];
+
+  for (const { scenario, jsonPath, result } of completed) {
+    lines.push(
+      `## ${scenario.name}`,
+      ``,
+      scenario.description,
+      ``,
+      `- mean: ${formatSeconds(result.mean)}`,
+      `- median: ${formatSeconds(result.median)}`,
+      `- min/max: ${formatSeconds(result.min)} / ${formatSeconds(result.max)}`,
+      `- stddev: ${formatSeconds(result.stddev)}`,
+      `- runs: ${scenario.runs}`,
+      `- warmup runs: ${scenario.warmup}`,
+      `- artifact: ${path.relative(path.dirname(summaryPath), jsonPath)}`,
+      ``,
+    );
+  }
+
+  await writeFile(summaryPath, `${lines.join("\n")}\n`);
+}
+
+function gitMetadata(cwd: string): Record<string, string> {
+  return {
+    branch: git(["branch", "--show-current"], cwd),
+    sha: git(["rev-parse", "HEAD"], cwd),
+  };
+}
+
+function git(args: string[], cwd: string): string {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  return result.status === 0 ? result.stdout.trim() : "unknown";
+}
+
+async function hashDirectory(dir: string): Promise<string> {
+  const hash = createHash("sha256");
+  for (const file of await listFiles(dir)) {
+    hash.update(path.relative(dir, file));
+    hash.update("\0");
+    hash.update(await readFile(file));
+    hash.update("\0");
+  }
+  return hash.digest("hex");
+}
+
+async function listFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(dir, entry.name);
+      return entry.isDirectory() ? listFiles(entryPath) : [entryPath];
+    }),
+  );
+  return files.flat().sort();
+}
+
+async function hashFile(file: string): Promise<string> {
+  return createHash("sha256")
+    .update(await readFile(file))
+    .digest("hex");
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+}

--- a/scripts/perf/run-vitest-bench.ts
+++ b/scripts/perf/run-vitest-bench.ts
@@ -1,0 +1,136 @@
+/// <reference types="node" />
+
+import { spawnSync } from "node:child_process";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { parseArgs } from "node:util";
+import { ensureDir, formatMilliseconds, repoRoot, resolveOutputDir, writeJson } from "./utils.ts";
+
+type BenchmarkReport = {
+  files?: {
+    filepath?: string;
+    groups?: {
+      fullName?: string;
+      benchmarks?: {
+        name?: string;
+        hz?: number;
+        mean?: number;
+        rme?: number;
+        samples?: unknown[];
+      }[];
+    }[];
+  }[];
+};
+
+async function main(): Promise<void> {
+  const { values } = parseArgs({
+    args: process.argv.slice(2).filter((arg) => arg !== "--"),
+    options: {
+      compare: { type: "string" },
+      "output-dir": { type: "string" },
+    },
+  });
+
+  const outputDir = resolveOutputDir(values["output-dir"], "vitest-bench");
+  const outputJson = path.join(outputDir, "render.json");
+  const compareJson = values.compare ?? process.env.PERF_VITEST_COMPARE;
+
+  await ensureDir(outputDir);
+  runVitestBench(outputJson, compareJson);
+
+  await writeJson(path.join(outputDir, "metadata.json"), {
+    createdAt: new Date().toISOString(),
+    repo: gitMetadata(repoRoot),
+    outputJson,
+    compareJson,
+  });
+  await writeSummary(path.join(outputDir, "summary.md"), outputJson);
+
+  console.log(`Wrote Vitest benchmark artifacts to ${path.relative(repoRoot, outputDir)}`);
+}
+
+function runVitestBench(outputJson: string, compareJson: string | undefined): void {
+  const command = [
+    "--dir",
+    "playground/rsc-vitest-demo",
+    "exec",
+    "vitest",
+    "bench",
+    "src/perf/render.bench.tsx",
+    "--outputJson",
+    outputJson,
+  ];
+
+  if (compareJson) {
+    command.push("--compare", compareJson);
+  }
+
+  const result = spawnSync("pnpm", command, {
+    cwd: repoRoot,
+    stdio: "inherit",
+  });
+
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`Vitest bench failed with exit code ${result.status}`);
+  }
+}
+
+async function writeSummary(summaryPath: string, outputJson: string): Promise<void> {
+  const report = JSON.parse(await readFile(outputJson, "utf8")) as BenchmarkReport;
+  const lines = [
+    `# Vitest Benchmark Summary`,
+    ``,
+    `Created: ${new Date().toISOString()}`,
+    ``,
+    `These timings are informational. The suite fails on benchmark execution errors, not on timing deltas.`,
+    ``,
+  ];
+
+  for (const file of report.files ?? []) {
+    for (const group of file.groups ?? []) {
+      lines.push(`## ${group.fullName ?? file.filepath ?? "benchmark"}`, ``);
+      for (const benchmark of group.benchmarks ?? []) {
+        lines.push(
+          `- ${benchmark.name ?? "unnamed"}: mean ${formatMilliseconds(
+            benchmark.mean,
+          )}, hz ${formatHz(benchmark.hz)}, rme ${formatPercent(benchmark.rme)}, samples ${
+            benchmark.samples?.length ?? 0
+          }`,
+        );
+      }
+      lines.push(``);
+    }
+  }
+
+  await writeFile(summaryPath, `${lines.join("\n")}\n`);
+}
+
+function gitMetadata(cwd: string): Record<string, string> {
+  return {
+    branch: git(["branch", "--show-current"], cwd),
+    sha: git(["rev-parse", "HEAD"], cwd),
+  };
+}
+
+function git(args: string[], cwd: string): string {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  return result.status === 0 ? result.stdout.trim() : "unknown";
+}
+
+function formatHz(value: unknown): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "n/a";
+  return `${value.toFixed(2)}/s`;
+}
+
+function formatPercent(value: unknown): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "n/a";
+  return `${value.toFixed(2)}%`;
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+}

--- a/scripts/perf/utils.ts
+++ b/scripts/perf/utils.ts
@@ -1,0 +1,62 @@
+/// <reference types="node" />
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const repoRoot = path.resolve(fileURLToPath(new URL("../../", import.meta.url)));
+
+export function resolveOutputDir(outputDirFlag: string | undefined, suite: string): string {
+  const outputDir =
+    outputDirFlag ??
+    process.env.PERF_OUTPUT_DIR ??
+    path.join(repoRoot, "artifacts", "perf", "local");
+
+  return path.resolve(outputDir, suite);
+}
+
+export async function ensureDir(dir: string): Promise<void> {
+  await mkdir(dir, { recursive: true });
+}
+
+export async function writeJson(filePath: string, value: unknown): Promise<void> {
+  await ensureDir(path.dirname(filePath));
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+export function sanitizeName(name: string): string {
+  return name.replaceAll(/[^a-zA-Z0-9._-]+/g, "-").replaceAll(/^-|-$/g, "");
+}
+
+export async function readPackageJson(packageRoot: string): Promise<Record<string, unknown>> {
+  return JSON.parse(await readFile(path.join(packageRoot, "package.json"), "utf8"));
+}
+
+export async function detectPackageRunner(packageRoot: string): Promise<"bun" | "pnpm" | "npm"> {
+  const packageJson = await readPackageJson(packageRoot);
+  const packageManager = String(packageJson.packageManager ?? "");
+
+  if (packageManager.startsWith("bun@")) return "bun";
+  if (packageManager.startsWith("pnpm@")) return "pnpm";
+  return "npm";
+}
+
+export function numberOption(value: string | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Expected a number, received "${value}".`);
+  }
+  return parsed;
+}
+
+export function formatSeconds(value: unknown): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "n/a";
+  return `${value.toFixed(3)}s`;
+}
+
+export function formatMilliseconds(value: unknown): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "n/a";
+  return `${value.toFixed(2)}ms`;
+}


### PR DESCRIPTION
## Summary
- Adds a Node 24-native performance harness for repo-local Vitest browser command benchmarks, with hyperfine JSON artifacts and markdown summaries under ignored `artifacts/perf`.
- Adds first-class `epic-rsc-stack` acceptance support that builds and packs the candidate plugin, installs that tarball into a generated external-app copy, verifies matching `dist` hashes, and then benchmarks the app's Vitest browser project.
- Adds a manual/scheduled Performance workflow that runs only portable repo-local benchmarks on Node 24/pnpm and uploads artifacts without gating every PR.

## Benchmark scenarios
- `playground/rsc-vitest-demo`: cold/warm full browser-mode `vitest run` plus a focused warm actions/payload/client-boundary scenario.
- `playground/nextjs-notes-demo`: cold/warm focused smoke tests for `auth-button` and `note-editor`.
- `epic-rsc-stack`: cold/warm `bun vitest run --project=browser` in a generated candidate workspace; optional warm coverage scenario via `--coverage`.
- Optional supporting micro layer: `pnpm perf:micro` runs Vitest bench for render helper hotspots, but it is not part of the default perf suite.

## Validation
- `pnpm format:check` passed.
- `pnpm lint` passed.
- `pnpm build` passed.
- `pnpm tsgo` passed.
- `pnpm test` passed.
- `PERF_OUTPUT_DIR=artifacts/perf/final PERF_HYPERFINE_RUNS=1 PERF_HYPERFINE_WARMUP=0 pnpm perf` passed. Local sample means: RSC all cold 4.404s, RSC all warm 4.469s, RSC focused actions/payload 2.651s, Next.js smoke cold 3.061s, Next.js smoke warm 3.217s.
- `PERF_OUTPUT_DIR=artifacts/perf/final ... pnpm perf:micro` passed. Short smoke settings produced render JSON successfully; samples are intentionally too small for conclusions.
- `PERF_OUTPUT_DIR=artifacts/perf/node-final-epic PERF_HYPERFINE_RUNS=1 PERF_HYPERFINE_WARMUP=0 pnpm perf:epic -- --show-output` prepared the generated epic workspace and verified the installed candidate package. `epic-preparation.json` showed matching source/installed `dist` SHA-256 (`4e73cf4715fd9147bd7d4f31a8929ff30a2e1f8c3c0cf25a09344b495d367b31`). The actual epic Vitest run then failed during dependency optimization because this branch's candidate package does not export `useRouter` from `dist/nextjs/navigation.react-server.js`, which `react-transition-progress` imports through `next/navigation`.

## Limitations / policy
- No timing thresholds yet; the suite fails on command failures, not small regressions.
- CI runs repo-local benchmarks only because `epic-rsc-stack` is external/local.
- Generated benchmark artifacts and generated epic workspaces are ignored and should not be committed.
- The current epic failure is a real acceptance blocker for the upcoming Next.js 16/runtime support work, not a perf harness failure.