### PR TITLE
ci: use Storybook bot for Release Please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,6 +24,7 @@ jobs:
       - id: release
         uses: googleapis/release-please-action@v4
         with:
+          token: ${{ secrets.PAT_STORYBOOK_BOT }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Summary
- Configure Release Please to use the existing `PAT_STORYBOOK_BOT` secret instead of the default `GITHUB_TOKEN`.
- This lets future Release Please PRs trigger normal pull request workflows and satisfy branch protection automatically.

## Test plan
- Validated `.github/workflows/release-please.yml` parses as YAML.
- Confirmed the PR diff only contains the Release Please workflow change.