### PR TITLE
feat: add React client coverage bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 coverage/
+*.lcov
 artifacts/perf/
 .vitest/
 **/.vitest/

--- a/packages/vitest-plugin-rsc/package.json
+++ b/packages/vitest-plugin-rsc/package.json
@@ -46,11 +46,14 @@
     "prepack": "tsdown"
   },
   "dependencies": {
+    "@jridgewell/gen-mapping": "^0.3.13",
     "@vitejs/plugin-rsc": "0.5.26",
     "@vitest/expect": "5.0.0-beta.2",
-    "@vitest/spy": "5.0.0-beta.2"
+    "@vitest/spy": "5.0.0-beta.2",
+    "convert-source-map": "^2.0.0"
   },
   "devDependencies": {
+    "@types/convert-source-map": "^2.0.3",
     "@types/estree": "^1.0.9",
     "@types/node": "^24.12.3",
     "@types/react": "^19.2.14",

--- a/packages/vitest-plugin-rsc/src/coverage.test.ts
+++ b/packages/vitest-plugin-rsc/src/coverage.test.ts
@@ -1,0 +1,165 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { MinimalPluginContextWithoutEnvironment, Plugin, ViteDevServer } from "vite";
+import { afterEach, expect, test, vi } from "vitest";
+import { createReactClientCoveragePlugin } from "./coverage";
+
+const reactClientCoverageModulePath = "/@vite/react-client-coverage-module";
+const reactClientCoverageQuery = "vitest-plugin-rsc-react-client-coverage";
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+test("loads recorded modules only through the coverage URL", async () => {
+  const file = await writeTempModule(`
+    "use server";
+
+    export async function action(formData: FormData) {
+      return Number(formData.get("count"));
+    }
+  `);
+  const { loadCoverageModule, postCoverageModule, moduleGraph } = setupCoveragePlugin();
+
+  await postCoverageModule({ file, code: "const answer = 42;\n" });
+
+  expect(loadCoverageModule(file)).toBeUndefined();
+  expect(loadCoverageModule(toCoverageId(file), "react_client")).toBeUndefined();
+  const coverageModule = loadCoverageModule(toCoverageId(file)) as
+    | { code: string; map: { sources: string[]; sourcesContent: string[] } }
+    | undefined;
+  expect(loadCoverageModule(toBrowserCoverageId(file))).toBe(coverageModule);
+  expect(coverageModule?.code).toContain("const answer = 42");
+  expect(coverageModule?.map.sources).toEqual([`file://${file}`]);
+  expect(coverageModule?.map.sourcesContent[0]).toContain("const answer = 42");
+  expect(moduleGraph.getModulesByFile).toHaveBeenCalledWith(file);
+});
+
+test('records modules with inline "use server" actions', async () => {
+  const file = await writeTempModule(`
+    export function createAction(count: number) {
+      return async function action(formData: FormData) {
+        "use server";
+        return count + Number(formData.get("count"));
+      };
+    }
+  `);
+  const { loadCoverageModule, postCoverageModule, moduleGraph } = setupCoveragePlugin();
+
+  await postCoverageModule({ file, code: "const answer = 42;\n" });
+
+  expect(loadCoverageModule(file)).toBeUndefined();
+  expect(loadCoverageModule(toCoverageId(file), "react_client")).toBeUndefined();
+  const coverageModule = loadCoverageModule(toCoverageId(file)) as
+    | { code: string; map: { sources: string[]; sourcesContent: string[] } }
+    | undefined;
+  expect(coverageModule?.code).toContain("const answer = 42");
+  expect(coverageModule?.map.sources).toEqual([`file://${file}`]);
+  expect(coverageModule?.map.sourcesContent[0]).toContain("const answer = 42");
+  expect(moduleGraph.getModulesByFile).toHaveBeenCalledWith(file);
+});
+
+async function writeTempModule(source: string) {
+  const dir = await mkdtemp(join(tmpdir(), "vitest-plugin-rsc-coverage-"));
+  tempDirs.push(dir);
+  const file = join(dir, "module.ts");
+  await writeFile(file, source);
+  return file;
+}
+
+function toCoverageId(file: string) {
+  return `${file}?${reactClientCoverageQuery}=1`;
+}
+
+function toBrowserCoverageId(file: string) {
+  const path = file.replace(/\\/g, "/");
+  return `http://localhost:5173/@fs${path}?${reactClientCoverageQuery}=1`;
+}
+
+function setupCoveragePlugin() {
+  const plugin = createReactClientCoveragePlugin();
+  let middleware: Middleware | undefined;
+  const moduleGraph = {
+    getModulesByFile: vi.fn(() => []),
+    invalidateModule: vi.fn(),
+  };
+  const server = {
+    middlewares: {
+      use: vi.fn((handler: Middleware) => {
+        middleware = handler;
+      }),
+    },
+    environments: {
+      client: {
+        moduleGraph,
+      },
+    },
+  } as unknown as ViteDevServer;
+
+  installPluginServer(plugin, server);
+
+  return {
+    moduleGraph,
+    async postCoverageModule(payload: { file: string; code: string }) {
+      if (!middleware) throw new Error("Coverage middleware was not installed.");
+
+      const req = jsonRequest(reactClientCoverageModulePath, payload);
+      const res = response();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(204);
+      expect(res.ended).toBe(true);
+    },
+    loadCoverageModule(file: string, environment = "client") {
+      const load = plugin.load as LoadHook | undefined;
+      if (!load) throw new Error("Coverage load hook was not installed.");
+      return load.call({ environment: { name: environment } }, file);
+    },
+  };
+}
+
+function installPluginServer(plugin: Plugin, server: ViteDevServer) {
+  const configureServer = plugin.configureServer;
+  if (typeof configureServer !== "function") {
+    throw new Error("Coverage configureServer hook was not installed.");
+  }
+  void configureServer.call({} as MinimalPluginContextWithoutEnvironment, server);
+}
+
+function jsonRequest(url: string, body: unknown): TestRequest {
+  return {
+    url,
+    async *[Symbol.asyncIterator]() {
+      yield new TextEncoder().encode(JSON.stringify(body));
+    },
+  };
+}
+
+function response(): TestResponse {
+  return {
+    statusCode: 200,
+    ended: false,
+    end() {
+      this.ended = true;
+    },
+  };
+}
+
+type Middleware = (req: TestRequest, res: TestResponse, next: () => void) => void | Promise<void>;
+
+type TestRequest = AsyncIterable<Uint8Array> & {
+  url: string;
+};
+
+type TestResponse = {
+  statusCode: number;
+  ended: boolean;
+  end(): void;
+};
+
+type LoadHook = (this: { environment: { name: string } }, id: string) => unknown;

--- a/packages/vitest-plugin-rsc/src/coverage.ts
+++ b/packages/vitest-plugin-rsc/src/coverage.ts
@@ -1,0 +1,165 @@
+import { addMapping, GenMapping, setSourceContent, toEncodedMap } from "@jridgewell/gen-mapping";
+import type { SourceMapInput } from "rolldown";
+import { type Plugin, type ViteDevServer } from "vite";
+import {
+  ssrDynamicImportKey,
+  ssrExportAllKey,
+  ssrExportNameKey,
+  ssrImportKey,
+  ssrImportMetaKey,
+  ssrModuleExportsKey,
+} from "vite/module-runner";
+import * as convertSourceMap from "convert-source-map";
+
+const reactClientCoverageModulePath = "/@vite/react-client-coverage-module";
+const reactClientCoverageQuery = "vitest-plugin-rsc-react-client-coverage";
+const moduleRunnerArgumentNames = [
+  ssrModuleExportsKey,
+  ssrImportMetaKey,
+  ssrImportKey,
+  ssrDynamicImportKey,
+  ssrExportAllKey,
+  ssrExportNameKey,
+];
+
+type ReactClientCoverageModule = {
+  code: string;
+  map: SourceMapInput;
+};
+
+export function createReactClientCoveragePlugin(): Plugin {
+  const modules = new Map<string, ReactClientCoverageModule>();
+
+  return {
+    name: "rsc:react-client-coverage",
+    enforce: "pre",
+    configureServer(server) {
+      server.middlewares.use(async (req, res, next) => {
+        const url = new URL(req.url ?? "/", "https://any.local");
+
+        if (url.pathname !== reactClientCoverageModulePath) {
+          next();
+          return;
+        }
+
+        const coverageModule = await readCoverageModule(req);
+        const id = normalizeCoverageFileId(coverageModule.file);
+        const code = wrapModuleRunnerCode(coverageModule.code);
+        const sourceMap = extractInlineSourceMap(coverageModule.code);
+
+        // The posted code already ran in the test iframe via Vite's
+        // ModuleRunner. Vitest's V8 provider later remaps browser coverage by
+        // asking the Browser Mode `client` graph for source and maps, so this
+        // mirrors the react_client transform result under a private URL.
+        modules.set(id, {
+          code,
+          map: hasMappings(sourceMap) ? sourceMap : createIdentitySourceMap(id, code),
+        });
+        invalidateClientModules(server, id);
+
+        res.statusCode = 204;
+        res.end();
+      });
+    },
+    load(id) {
+      if (this.environment.name !== "client") return;
+      if (!isReactClientCoverageId(id)) return;
+      return modules.get(normalizeCoverageFileId(id));
+    },
+  };
+}
+
+function isReactClientCoverageId(id: string) {
+  const query = id.split("?", 2)[1];
+  return query !== undefined && new URLSearchParams(query).has(reactClientCoverageQuery);
+}
+
+async function readCoverageModule(req: AsyncIterable<Uint8Array>) {
+  const decoder = new TextDecoder();
+  let json = "";
+
+  for await (const chunk of req) {
+    json += decoder.decode(chunk, { stream: true });
+  }
+
+  json += decoder.decode();
+
+  const body = JSON.parse(json) as { file: string; code: string };
+  if (typeof body.file !== "string" || typeof body.code !== "string") {
+    throw new TypeError("Invalid react client coverage module payload.");
+  }
+  return body;
+}
+
+function extractInlineSourceMap(code: string) {
+  return convertSourceMap.fromSource(code)?.toObject();
+}
+
+function hasMappings(map: unknown): map is { mappings: string } {
+  return (
+    typeof map === "object" &&
+    map !== null &&
+    "mappings" in map &&
+    typeof map.mappings === "string" &&
+    map.mappings.length > 0
+  );
+}
+
+function createIdentitySourceMap(file: string, code: string) {
+  const source = `file://${file}`;
+  const map = new GenMapping();
+
+  setSourceContent(map, source, code);
+
+  for (let line = 1; line <= code.split("\n").length; line++) {
+    addMapping(map, {
+      generated: { line, column: 0 },
+      source,
+      original: { line, column: 0 },
+    });
+  }
+
+  return toEncodedMap(map);
+}
+
+function wrapModuleRunnerCode(code: string) {
+  const AsyncFunction = async function () {}.constructor as new (
+    ...args: string[]
+  ) => (...args: unknown[]) => Promise<unknown>;
+
+  return new AsyncFunction(...moduleRunnerArgumentNames, `"use strict";${code}`).toString();
+}
+
+function normalizeCoverageFileId(id: string) {
+  const cleanId = id.split(/[?#]/, 1)[0]!;
+  let pathname = cleanId;
+
+  if (cleanId.startsWith("file://")) {
+    return fileUrlToPath(cleanId);
+  }
+
+  if (cleanId.startsWith("http://") || cleanId.startsWith("https://")) {
+    pathname = decodeURIComponent(new URL(cleanId).pathname);
+  }
+
+  if (pathname.startsWith("/@fs/")) {
+    return pathname.slice("/@fs".length);
+  }
+
+  return pathname;
+}
+
+function fileUrlToPath(id: string) {
+  const url = new URL(id);
+  const pathname = decodeURIComponent(url.pathname);
+  if (url.hostname) return `//${url.hostname}${pathname}`;
+  return pathname.replace(/^\/([A-Za-z]:)/, "$1");
+}
+
+function invalidateClientModules(server: ViteDevServer, file: string) {
+  const modules = server.environments.client.moduleGraph.getModulesByFile(file) ?? [];
+
+  for (const moduleNode of modules) {
+    server.environments.client.moduleGraph.invalidateModule(moduleNode);
+  }
+}

--- a/packages/vitest-plugin-rsc/src/index.ts
+++ b/packages/vitest-plugin-rsc/src/index.ts
@@ -1,5 +1,6 @@
 import { type Plugin, type ViteDevServer } from "vite";
 import { vitePluginRscMinimal } from "@vitejs/plugin-rsc/plugin";
+import { createReactClientCoveragePlugin } from "./coverage";
 
 const reactClientWebSocketInfoPath = "/@vite/react-client-runner-websocket";
 const reactClientWebSocketQuery = "vitest-plugin-rsc-react-client";
@@ -134,6 +135,7 @@ export function vitestPluginRSC(): Plugin[] {
         ];
       },
     },
+    createReactClientCoveragePlugin(),
   ];
 }
 

--- a/packages/vitest-plugin-rsc/src/utilts.ts
+++ b/packages/vitest-plugin-rsc/src/utilts.ts
@@ -1,12 +1,19 @@
 import { ESModulesEvaluator, ModuleRunner, type ModuleRunnerTransport } from "vite/module-runner";
 
+const reactClientCoverageModulePath = "/@vite/react-client-coverage-module";
 const reactClientWebSocketInfoPath = "/@vite/react-client-runner-websocket";
 const reactClientWebSocketQuery = "vitest-plugin-rsc-react-client";
+const reactClientCoverageQuery = "vitest-plugin-rsc-react-client-coverage";
 const reactClientWebSocketInvokeEvent = "vitest-plugin-rsc:react-client:invoke";
 const reactClientWebSocketInvokeResultEvent = "vitest-plugin-rsc:react-client:invoke-result";
+const sourceUrlRE = /\/\/# sourceURL=[^\n\r]*/;
 
 type InvokePayload = Parameters<NonNullable<ModuleRunnerTransport["invoke"]>>[0];
 type InvokeResult = Awaited<ReturnType<NonNullable<ModuleRunnerTransport["invoke"]>>>;
+type ViteFetchResult = {
+  code: string;
+  file: string;
+};
 
 type WebSocketInfo = {
   token: string;
@@ -51,6 +58,91 @@ const runner = new ModuleRunner(
 export const importReactClient = runner.import.bind(runner);
 
 async function invokeReactClient(payload: InvokePayload) {
+  return await withReactClientCoverage(await invokeReactClientOverWebSocket(payload));
+}
+
+async function withReactClientCoverage(result: InvokeResult) {
+  if (
+    !isCoverageEnabled() ||
+    !isInvokeSuccess(result) ||
+    !isViteFetchResult(result.result) ||
+    isNodeModuleFile(result.result.file)
+  ) {
+    return result;
+  }
+
+  // Vitest's V8 coverage runs in the Browser Mode worker, while client
+  // components are evaluated by this separate react_client ModuleRunner.
+  const sourceUrl = toBrowserCoverageFileUrl(result.result.file);
+  const code = withBrowserSourceUrl(result.result.code, sourceUrl);
+
+  await recordEvaluatedModule(result.result.file, code);
+
+  return {
+    ...result,
+    result: {
+      ...result.result,
+      code,
+    },
+  };
+}
+
+function isInvokeSuccess(result: InvokeResult): result is { result: unknown } {
+  return typeof result === "object" && result !== null && "result" in result;
+}
+
+function isCoverageEnabled() {
+  const worker = globalThis as typeof globalThis & {
+    __vitest_worker__?: { config?: { coverage?: { enabled?: boolean } } };
+  };
+
+  return Boolean(worker.__vitest_worker__?.config?.coverage?.enabled);
+}
+
+function isViteFetchResult(value: unknown): value is ViteFetchResult {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "code" in value &&
+    "file" in value &&
+    typeof value.code === "string" &&
+    typeof value.file === "string"
+  );
+}
+
+function isNodeModuleFile(file: string) {
+  return file.replace(/\\/g, "/").includes("/node_modules/");
+}
+
+function withBrowserSourceUrl(code: string, sourceUrl: string) {
+  const sourceUrlComment = `//# sourceURL=${sourceUrl}`;
+  return sourceUrlRE.test(code)
+    ? code.replace(sourceUrlRE, sourceUrlComment)
+    : `${code}\n${sourceUrlComment}`;
+}
+
+async function recordEvaluatedModule(file: string, code: string) {
+  await fetch(reactClientCoverageModulePath, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ file, code }),
+  });
+}
+
+function toBrowserCoverageFileUrl(file: string) {
+  const path = file.replace(/\\/g, "/");
+  const encodedPath = encodeURI(path).replace(/\?/g, "%3F").replace(/#/g, "%23");
+  const url = new URL(
+    `/@fs${encodedPath.startsWith("/") ? "" : "/"}${encodedPath}`,
+    window.location.origin,
+  );
+  url.searchParams.set(reactClientCoverageQuery, "1");
+  return url.href;
+}
+
+async function invokeReactClientOverWebSocket(payload: InvokePayload) {
   const socket = await getReactClientWebSocket();
   const info = await getWebSocketInfo();
   const id = String(++nextInvokeId);

--- a/packages/vitest-plugin-rsc/src/utilts.ts
+++ b/packages/vitest-plugin-rsc/src/utilts.ts
@@ -122,12 +122,15 @@ function withBrowserSourceUrl(code: string, sourceUrl: string) {
 }
 
 async function recordEvaluatedModule(file: string, code: string) {
-  await fetch(reactClientCoverageModulePath, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-    },
-    body: JSON.stringify({ file, code }),
+  await new Promise<void>((resolve, reject) => {
+    const request = new XMLHttpRequest();
+    request.open("POST", reactClientCoverageModulePath);
+    request.setRequestHeader("content-type", "application/json");
+    request.addEventListener("load", () => resolve());
+    request.addEventListener("error", () =>
+      reject(new Error("Failed to record React client coverage module")),
+    );
+    request.send(JSON.stringify({ file, code }));
   });
 }
 

--- a/playground/nextjs-notes-demo/package.json
+++ b/playground/nextjs-notes-demo/package.json
@@ -66,6 +66,7 @@
     "@vitejs/plugin-rsc": "0.5.26",
     "@vitest/browser": "5.0.0-beta.2",
     "@vitest/browser-playwright": "5.0.0-beta.2",
+    "@vitest/coverage-v8": "5.0.0-beta.2",
     "@vitest/ui": "5.0.0-beta.2",
     "babel-plugin-react-compiler": "1.0.0",
     "drizzle-kit": "^0.31.10",

--- a/playground/rsc-vitest-demo/package.json
+++ b/playground/rsc-vitest-demo/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview",
     "test": "rm -rf .vite && vitest",
     "test:run": "rm -rf .vite && vitest run",
+    "test:coverage": "rm -rf .vite && vitest run --coverage",
     "test:watch": "vitest watch"
   },
   "dependencies": {

--- a/playground/rsc-vitest-demo/vitest.config.ts
+++ b/playground/rsc-vitest-demo/vitest.config.ts
@@ -5,6 +5,12 @@ import { vitestPluginRSC } from "vitest-plugin-rsc";
 export default defineConfig({
   plugins: [vitestPluginRSC()],
   test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html", "lcov"],
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: ["src/**/*.test.{ts,tsx}", "src/vitest.setup.ts"],
+    },
     restoreMocks: true,
     browser: {
       enabled: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
 
   packages/vitest-plugin-rsc:
     dependencies:
+      '@jridgewell/gen-mapping':
+        specifier: ^0.3.13
+        version: 0.3.13
       '@vitejs/plugin-rsc':
         specifier: 0.5.26
         version: 0.5.26(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0))
@@ -47,7 +50,13 @@ importers:
       '@vitest/spy':
         specifier: 5.0.0-beta.2
         version: 5.0.0-beta.2
+      convert-source-map:
+        specifier: ^2.0.0
+        version: 2.0.0
     devDependencies:
+      '@types/convert-source-map':
+        specifier: ^2.0.3
+        version: 2.0.3
       '@types/estree':
         specifier: ^1.0.9
         version: 1.0.9
@@ -248,6 +257,9 @@ importers:
       '@vitest/browser-playwright':
         specifier: 5.0.0-beta.2
         version: 5.0.0-beta.2(msw@2.14.5(@types/node@24.12.3)(typescript@6.0.3))(playwright@1.59.1)(vite@8.0.11(@types/node@24.12.3)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0))(vitest@5.0.0-beta.2)
+      '@vitest/coverage-v8':
+        specifier: 5.0.0-beta.2
+        version: 5.0.0-beta.2(@vitest/browser@5.0.0-beta.2)(vitest@5.0.0-beta.2)
       '@vitest/ui':
         specifier: 5.0.0-beta.2
         version: 5.0.0-beta.2(vitest@5.0.0-beta.2)
@@ -1369,6 +1381,9 @@ packages:
   '@jridgewell/gen-mapping@0.3.12':
     resolution: {integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==}
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
   '@jridgewell/remapping@2.3.5':
     resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
 
@@ -2208,6 +2223,9 @@ packages:
 
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
+
+  '@types/convert-source-map@2.0.3':
+    resolution: {integrity: sha512-ag0BfJLZf6CQz8VIuRIEYQ5Ggwk/82uvTQf27RcpyDNbY0Vw49LIPqAxk5tqYfrCs9xDaIMvl4aj7ZopnYL8bA==}
 
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
@@ -5280,6 +5298,11 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.29
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/remapping@2.3.5':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.12
@@ -5883,6 +5906,8 @@ snapshots:
   '@types/chai@5.2.2':
     dependencies:
       '@types/deep-eql': 4.0.2
+
+  '@types/convert-source-map@2.0.3': {}
 
   '@types/cookie@0.6.0': {}
 


### PR DESCRIPTION
## Summary
- Replays only the React client V8 coverage bridge from the reverted PR #9 on top of latest main.
- Records evaluated `react_client` ModuleRunner code under private coverage URLs so Browser Mode V8 coverage can remap it through the client graph.
- Adds focused coverage tests and the missing coverage provider/config bits needed to run the playground coverage smoke test.

## Test plan
- `pnpm --filter vitest-plugin-rsc run build`
- `pnpm --filter vitest-plugin-rsc exec vitest run src/coverage.test.ts`
- `pnpm --filter vitest-plugin-rsc exec vitest run src`
- `pnpm --dir playground/rsc-vitest-demo exec vitest run src/action-from-client/client.test.tsx --coverage`