### PR TITLE
fix: stabilize notes demo CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
     branches: [main]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   format:

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: read
 

--- a/playground/nextjs-notes-demo/vitest.config.ts
+++ b/playground/nextjs-notes-demo/vitest.config.ts
@@ -8,6 +8,9 @@ import "#env/load-next.ts";
 // oxlint-disable-next-line no-process-env
 process.env.LAUNCH_EDITOR = "/usr/bin/true";
 
+// oxlint-disable-next-line no-process-env
+const maxWorkers = process.env.CI ? undefined : 4;
+
 export default defineConfig({
   envPrefix: ["VITE_", "CI"],
   resolve: {
@@ -28,7 +31,7 @@ export default defineConfig({
     ],
   },
   test: {
-    maxWorkers: 4,
+    maxWorkers,
     coverage: {
       provider: "v8",
       reporter: ["text", "html", "lcov"],

--- a/playground/nextjs-notes-demo/vitest.setup.ts
+++ b/playground/nextjs-notes-demo/vitest.setup.ts
@@ -66,12 +66,14 @@ const MOBILE_VIEWPORT = { width: 390, height: 844 } as const;
 const TEST_NOW = "2026-05-06T00:00:00.000Z";
 
 let base: PGlite;
+let currentDbClient: PGlite | undefined;
 let pointerResetTarget: HTMLElement | undefined;
 const worker = setupWorker(...nextCacheProbeFetchHandler, ...nextRscRequestHandlers);
 
-// Vitest mounts React into an existing document, so rendering RootLayout's
-// <html>/<body> tags would be invalid. Page tests use the app-local
-// renderServer helper and keep the matching document-level defaults here.
+// Vitest mounts React into an existing document. Route tests intentionally let
+// the plugin render RootLayout's <html>/<body> tags into that mount so the
+// route tree matches Next's app-render output; keep matching document defaults
+// here for assertions that read document-level state.
 function applyDocumentDefaults() {
   document.documentElement.lang = "en";
   document.documentElement.className = "antialiased";
@@ -108,6 +110,13 @@ async function resetInteractiveState() {
   await page.elementLocator(pointerResetTarget).hover();
 }
 
+async function closeCurrentDbClient() {
+  if (currentDbClient && !currentDbClient.closed) {
+    await currentDbClient.close();
+  }
+  currentDbClient = undefined;
+}
+
 beforeAll(async () => {
   await worker.start({
     onUnhandledRequest: "bypass",
@@ -122,6 +131,7 @@ beforeAll(async () => {
 beforeEach(async () => {
   worker.resetHandlers();
   await cleanup();
+  await closeCurrentDbClient();
   setCurrentUser(null);
   deleteFlashCookies();
   applyDocumentDefaults();
@@ -129,6 +139,7 @@ beforeEach(async () => {
   if (!(clone instanceof PGlite)) {
     throw new TypeError("Expected PGlite.clone() to return a PGlite instance");
   }
+  currentDbClient = clone;
   resetDb(drizzle(clone, { schema }));
 
   vi.setSystemTime(new Date(TEST_NOW));
@@ -144,6 +155,9 @@ afterEach(async () => {
   await page.viewport(MOBILE_VIEWPORT.width, MOBILE_VIEWPORT.height);
 });
 
-afterAll(() => {
+afterAll(async () => {
+  await cleanup();
+  await closeCurrentDbClient();
+  await base.close();
   worker.stop();
 });


### PR DESCRIPTION
## Summary
- Cancel superseded pull request runs for CI, Preview Package, and Semantic Pull Request checks so new commits replace stale work.
- Close cloned PGlite clients between notes-demo browser tests and during teardown to avoid leaking database state/resources.
- Use four Vitest workers locally for the notes demo while letting CI use Vitest's default worker selection.

## Test plan
- `pnpm --dir playground/nextjs-notes-demo exec vitest run --reporter=dot`
- `CI=1 pnpm --dir playground/nextjs-notes-demo exec vitest run --reporter=dot`
- `pnpm build`
- `pnpm --filter vitest-plugin-rsc run test:run`
- `pnpm --filter nextjs-no-msw-demo run test:run`
- GitHub Actions CI passed on the cleaned branch.