### PR TITLE
test: stop clearing Vite cache before RSC demo runs

### DIFF
--- a/playground/rsc-vitest-demo/package.json
+++ b/playground/rsc-vitest-demo/package.json
@@ -7,9 +7,9 @@
     "build": "tsc -b && vite build",
     "check": "tsc -b",
     "preview": "vite preview",
-    "test": "rm -rf .vite && vitest",
-    "test:run": "rm -rf .vite && vitest run",
-    "test:coverage": "rm -rf .vite && vitest run --coverage",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:watch": "vitest watch"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Remove the `rm -rf .vite` prefix from the RSC playground Vitest scripts.
- Avoid deleting shared Vite cache state when multiple agents run tests from the same checkout.

## Test plan
- Not run; per request, no Vitest commands were executed.