### PR TITLE
feat: support concurrent browser async context

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Pick one piece of the app — a wishlist carousel, a notes form, a settings pane
   - [Register The Plugin](#2-register-the-plugin)
   - [Boot The Runtime](#3-boot-the-runtime)
   - [Browser-Compatible Server Code](#4-browser-compatible-server-code)
-- [Test Concurrency](#test-concurrency)
 - [Example: Server Action Form](#example-server-action-form)
 - [Example: Drizzle + PGlite Setup](#example-drizzle--pglite-setup)
 - [Next.js App Router Helpers](#nextjs-app-router-helpers)
@@ -253,10 +252,6 @@ export default defineConfig({
   plugins: [nodePolyfills(), vitestPluginRSC()],
 });
 ```
-
-## Test Concurrency
-
-[`test.concurrent`](https://vitest.dev/api/#test-concurrent) doesn't work for tests that read `AsyncLocalStorage`, which includes anything that touches Next.js App Router internals (`headers()`, `cookies()`, `next/cache`, Server Actions). The plugin's `AsyncLocalStorage` shim is sequential, so concurrent tests would leak context between each other. Sequential tests within a file are fine; test files still run in parallel.
 
 ## Example: Server Action Form
 

--- a/packages/vitest-plugin-rsc/package.json
+++ b/packages/vitest-plugin-rsc/package.json
@@ -46,11 +46,14 @@
     "prepack": "tsdown"
   },
   "dependencies": {
+    "@babel/parser": "^7.29.3",
     "@jridgewell/gen-mapping": "^0.3.13",
     "@vitejs/plugin-rsc": "0.5.26",
     "@vitest/expect": "5.0.0-beta.2",
     "@vitest/spy": "5.0.0-beta.2",
-    "convert-source-map": "^2.0.0"
+    "convert-source-map": "^2.0.0",
+    "magic-string": "^0.30.21",
+    "unctx": "^2.5.0"
   },
   "devDependencies": {
     "@types/convert-source-map": "^2.0.3",

--- a/packages/vitest-plugin-rsc/src/async-local-storage-transform.test.ts
+++ b/packages/vitest-plugin-rsc/src/async-local-storage-transform.test.ts
@@ -68,6 +68,20 @@ export async function load() {
   expectParseable(output!);
 });
 
+test("keeps function directives before injected locals", () => {
+  const output = transform(`
+export async function action() {
+  "use server";
+  await save();
+}
+`);
+
+  expect(output).toBeDefined();
+  expect(output).toContain(`"use server";\nlet __vitestPluginRscTemp`);
+  expect(output).toContain("__vitestPluginRscExecuteAsync(async()=>save())");
+  expectParseable(output!);
+});
+
 test("does not inject an empty statement before single-statement loop bodies", () => {
   const output = transform(`
 export async function visitAll(items: string[]) {

--- a/packages/vitest-plugin-rsc/src/async-local-storage-transform.test.ts
+++ b/packages/vitest-plugin-rsc/src/async-local-storage-transform.test.ts
@@ -1,0 +1,81 @@
+import { parse } from "@babel/parser";
+import { expect, test } from "vitest";
+import { createAsyncLocalStorageTransformPlugin } from "./async-local-storage-transform";
+
+type TransformOutput = { code: string };
+
+const transformHook = createAsyncLocalStorageTransformPlugin().transform as (
+  code: string,
+  id: string,
+) => TransformOutput | undefined;
+
+function transform(code: string, id = "/workspace/src/example.test.tsx"): string | undefined {
+  return transformHook(code, id)?.code;
+}
+
+function expectParseable(code: string): void {
+  expect(() =>
+    parse(code, {
+      sourceType: "module",
+      plugins: ["jsx", "typescript", "importAttributes"],
+    }),
+  ).not.toThrow();
+}
+
+test("inserts the helper import after module directives", () => {
+  const output = transform(`
+"use client";
+
+export async function load() {
+  return await fetchData();
+}
+`);
+
+  expect(output).toBeDefined();
+  expect(output).toContain(
+    `"use client";\n/* _processed_vitest_plugin_rsc_async_context */\nimport { executeAsync as __vitestPluginRscExecuteAsync } from "vitest-plugin-rsc/async-local-storage";`,
+  );
+  expectParseable(output!);
+});
+
+test("skips files that should not be transformed", () => {
+  const code = "export async function load() { return await fetchData(); }";
+
+  expect(transform(code, "/workspace/node_modules/pkg/file.ts")).toBeUndefined();
+  expect(
+    transform(code, "/workspace/packages/vitest-plugin-rsc/dist/testing-library-client.js"),
+  ).toBeUndefined();
+  expect(transform(code, "/workspace/src/vitest.setup.ts")).toBeUndefined();
+  expect(transform("export function load() { return fetchData(); }")).toBeUndefined();
+});
+
+test("does not transform a file twice", () => {
+  const output = transform("export async function load() { return await fetchData(); }");
+
+  expect(output).toBeDefined();
+  expect(transform(output!)).toBeUndefined();
+});
+
+test("keeps transformed nested awaits parseable", () => {
+  const output = transform(`
+export async function load() {
+  return await first(await second());
+}
+`);
+
+  expect(output).toBeDefined();
+  expect(output).toContain("__vitestPluginRscExecuteAsync");
+  expectParseable(output!);
+});
+
+test("does not inject an empty statement before single-statement loop bodies", () => {
+  const output = transform(`
+export async function visitAll(items: string[]) {
+  for (const item of items) await visit(item);
+}
+`);
+
+  expect(output).toBeDefined();
+  expect(output).not.toContain("for (const item of items) ;(");
+  expectParseable(output!);
+});

--- a/packages/vitest-plugin-rsc/src/async-local-storage-transform.ts
+++ b/packages/vitest-plugin-rsc/src/async-local-storage-transform.ts
@@ -115,7 +115,11 @@ function transformAsyncFunctionBody(s: MagicString, body: AstNode): boolean {
   });
 
   if (transformed && typeof body.start === "number") {
-    s.appendLeft(body.start + 1, `let ${tempName}, ${restoreName};`);
+    const insertionIndex = getBlockBodyInsertionIndex(body);
+    s.appendLeft(
+      insertionIndex,
+      `${insertionIndex === body.start + 1 ? "" : "\n"}let ${tempName}, ${restoreName};`,
+    );
   }
 
   return transformed;
@@ -129,20 +133,23 @@ function injectAwaitRestore(
   grandparent: AstNode | undefined,
 ): void {
   const nodeStart = node.start!;
-  const nodeEnd = node.end!;
   const argumentStart = argument.start!;
   const argumentEnd = argument.end!;
   const isStatement = parent?.type === "ExpressionStatement";
   const needsLeadingSemicolon = isStatement && !isSingleStatementBody(parent, grandparent);
 
   s.remove(nodeStart, argumentStart);
-  s.remove(nodeEnd, argumentEnd);
-  s.appendLeft(argumentStart, needsLeadingSemicolon ? `;(${tempName}=` : `(${tempName}=`);
+  s.appendLeft(
+    argumentStart,
+    needsLeadingSemicolon
+      ? `;([${tempName},${restoreName}]=${executeAsyncName}(async()=>`
+      : `([${tempName},${restoreName}]=${executeAsyncName}(async()=>`,
+  );
   s.appendRight(
     argumentEnd,
     isStatement
-      ? `,[${tempName},${restoreName}]=${executeAsyncName}(()=>${tempName}),await ${tempName},${restoreName}());`
-      : `,[${tempName},${restoreName}]=${executeAsyncName}(()=>${tempName}),${tempName}=await ${tempName},${restoreName}(),${tempName})`,
+      ? `),await ${tempName},${restoreName}());`
+      : `),${tempName}=await ${tempName},${restoreName}(),${tempName})`,
   );
 }
 
@@ -183,6 +190,27 @@ function getImportInsertionIndex(ast: AstNode): number {
 
   let index = 0;
   for (const node of body) {
+    if (!isDirectiveStatement(node)) break;
+    index = typeof node.end === "number" ? node.end : index;
+  }
+
+  return index;
+}
+
+function getBlockBodyInsertionIndex(body: AstNode): number {
+  const directives = body.directives;
+  if (Array.isArray(directives) && directives.length > 0) {
+    const lastDirective = directives[directives.length - 1];
+    if (isAstNode(lastDirective) && typeof lastDirective.end === "number") {
+      return lastDirective.end;
+    }
+  }
+
+  const statements = body.body;
+  if (!Array.isArray(statements)) return (body.start ?? 0) + 1;
+
+  let index = (body.start ?? 0) + 1;
+  for (const node of statements) {
     if (!isDirectiveStatement(node)) break;
     index = typeof node.end === "number" ? node.end : index;
   }

--- a/packages/vitest-plugin-rsc/src/async-local-storage-transform.ts
+++ b/packages/vitest-plugin-rsc/src/async-local-storage-transform.ts
@@ -1,0 +1,230 @@
+import type { Plugin } from "vite";
+import { parse } from "@babel/parser";
+import MagicString from "magic-string";
+
+type AstNode = {
+  type: string;
+  start?: number | null;
+  end?: number | null;
+  async?: boolean;
+  argument?: AstNode | null;
+  body?: AstNode | AstNode[] | null;
+  expression?: AstNode | null;
+  value?: unknown;
+  [key: string]: unknown;
+};
+
+const helperModule = "vitest-plugin-rsc/async-local-storage";
+const executeAsyncName = "__vitestPluginRscExecuteAsync";
+const tempName = "__vitestPluginRscTemp";
+const restoreName = "__vitestPluginRscRestore";
+const transformedMarker = "/* _processed_vitest_plugin_rsc_async_context */\n";
+const transformedMarkerRE = /^\/\* _processed_vitest_plugin_rsc_async_context \*\/\n/;
+
+export function createAsyncLocalStorageTransformPlugin(): Plugin {
+  return {
+    name: "rsc:async-local-storage-transform",
+    enforce: "post",
+    applyToEnvironment(environment) {
+      return environment.name === "client" || environment.name === "react_client";
+    },
+    transform(code, id) {
+      if (!shouldTransform(id, code)) return;
+
+      let ast: AstNode;
+      try {
+        ast = parse(code, {
+          sourceType: "module",
+          plugins: ["jsx", "typescript", "importAttributes"],
+        }) as unknown as AstNode;
+      } catch {
+        return;
+      }
+
+      const s = new MagicString(code);
+      let transformed = false;
+
+      walk(ast, (node) => {
+        const body = node.body;
+        if (
+          !isFunctionNode(node) ||
+          node.async !== true ||
+          !isAstNode(body) ||
+          body.type !== "BlockStatement"
+        ) {
+          return;
+        }
+
+        if (transformAsyncFunctionBody(s, body)) {
+          transformed = true;
+        }
+      });
+
+      if (!transformed) return;
+
+      const importInsertionIndex = getImportInsertionIndex(ast);
+      s.appendLeft(
+        importInsertionIndex,
+        `${importInsertionIndex > 0 ? "\n" : ""}${transformedMarker}import { executeAsync as ${executeAsyncName} } from ${JSON.stringify(
+          helperModule,
+        )};\n`,
+      );
+
+      return {
+        code: s.toString(),
+        map: s.generateMap({
+          source: id,
+          includeContent: true,
+        }),
+      };
+    },
+  };
+}
+
+function shouldTransform(id: string, code: string): boolean {
+  if (!code.includes("await") || transformedMarkerRE.test(code)) return false;
+
+  const [file] = id.split("?", 1);
+  if (!file || file.includes("/node_modules/")) return false;
+  if (file.includes("/packages/vitest-plugin-rsc/dist/")) return false;
+  if (/[/\\]vitest\.setup(?:\.[\w-]+)?\.[cm]?[jt]sx?$/.test(file)) return false;
+
+  return /\.[cm]?[jt]sx?$/.test(file);
+}
+
+function transformAsyncFunctionBody(s: MagicString, body: AstNode): boolean {
+  let transformed = false;
+
+  walk(body, (node, parent, grandparent) => {
+    if (node !== body && isFunctionNode(node)) return false;
+    if (node.type !== "AwaitExpression") return;
+
+    const argument = node.argument;
+    if (
+      !isAstNode(argument) ||
+      typeof node.start !== "number" ||
+      typeof node.end !== "number" ||
+      typeof argument.start !== "number" ||
+      typeof argument.end !== "number"
+    ) {
+      return;
+    }
+
+    transformed = true;
+    injectAwaitRestore(s, node, argument, parent, grandparent);
+  });
+
+  if (transformed && typeof body.start === "number") {
+    s.appendLeft(body.start + 1, `let ${tempName}, ${restoreName};`);
+  }
+
+  return transformed;
+}
+
+function injectAwaitRestore(
+  s: MagicString,
+  node: AstNode,
+  argument: AstNode,
+  parent: AstNode | undefined,
+  grandparent: AstNode | undefined,
+): void {
+  const nodeStart = node.start!;
+  const nodeEnd = node.end!;
+  const argumentStart = argument.start!;
+  const argumentEnd = argument.end!;
+  const isStatement = parent?.type === "ExpressionStatement";
+  const needsLeadingSemicolon = isStatement && !isSingleStatementBody(parent, grandparent);
+
+  s.remove(nodeStart, argumentStart);
+  s.remove(nodeEnd, argumentEnd);
+  s.appendLeft(argumentStart, needsLeadingSemicolon ? `;(${tempName}=` : `(${tempName}=`);
+  s.appendRight(
+    argumentEnd,
+    isStatement
+      ? `,[${tempName},${restoreName}]=${executeAsyncName}(()=>${tempName}),await ${tempName},${restoreName}());`
+      : `,[${tempName},${restoreName}]=${executeAsyncName}(()=>${tempName}),${tempName}=await ${tempName},${restoreName}(),${tempName})`,
+  );
+}
+
+function isFunctionNode(node: AstNode): boolean {
+  return (
+    node.type === "ArrowFunctionExpression" ||
+    node.type === "FunctionDeclaration" ||
+    node.type === "FunctionExpression" ||
+    node.type === "ObjectMethod" ||
+    node.type === "ClassMethod" ||
+    node.type === "ClassPrivateMethod"
+  );
+}
+
+function isSingleStatementBody(node: AstNode, parent: AstNode | undefined): boolean {
+  if (!parent) return false;
+
+  return (
+    parent.body === node ||
+    parent.consequent === node ||
+    parent.alternate === node ||
+    parent.delegate === node
+  );
+}
+
+function getImportInsertionIndex(ast: AstNode): number {
+  const program = isAstNode(ast.program) ? ast.program : ast;
+  const directives = program.directives;
+  if (Array.isArray(directives) && directives.length > 0) {
+    const lastDirective = directives[directives.length - 1];
+    if (isAstNode(lastDirective) && typeof lastDirective.end === "number") {
+      return lastDirective.end;
+    }
+  }
+
+  const body = program.body;
+  if (!Array.isArray(body)) return 0;
+
+  let index = 0;
+  for (const node of body) {
+    if (!isDirectiveStatement(node)) break;
+    index = typeof node.end === "number" ? node.end : index;
+  }
+
+  return index;
+}
+
+function isDirectiveStatement(node: AstNode): boolean {
+  const expression = node.expression;
+  return (
+    node.type === "ExpressionStatement" &&
+    expression?.type === "StringLiteral" &&
+    typeof expression.value === "string"
+  );
+}
+
+function walk(
+  node: AstNode,
+  enter: (
+    node: AstNode,
+    parent: AstNode | undefined,
+    grandparent: AstNode | undefined,
+  ) => false | void,
+  parent?: AstNode,
+  grandparent?: AstNode,
+): void {
+  if (enter(node, parent, grandparent) === false) return;
+
+  for (const [key, value] of Object.entries(node)) {
+    if (key === "loc" || key === "leadingComments" || key === "trailingComments") continue;
+
+    if (Array.isArray(value)) {
+      for (const child of value) {
+        if (isAstNode(child)) walk(child, enter, node, parent);
+      }
+      continue;
+    }
+
+    if (isAstNode(value)) walk(value, enter, node, parent);
+  }
+}
+
+function isAstNode(value: unknown): value is AstNode {
+  return typeof value === "object" && value !== null && typeof (value as AstNode).type === "string";
+}

--- a/packages/vitest-plugin-rsc/src/async-local-storage.test.ts
+++ b/packages/vitest-plugin-rsc/src/async-local-storage.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from "vitest";
-import { createAsyncLocalStorage, executeAsync, resetAsyncLocalStorage } from "./async-local-storage";
+import {
+  createAsyncLocalStorage,
+  executeAsync,
+  resetAsyncLocalStorage,
+} from "./async-local-storage";
 import {
   AsyncLocalStorage,
   AsyncResource,
@@ -20,6 +24,15 @@ function deferred<T>() {
 
 async function preserveAsyncLocalStorage<T>(value: T | PromiseLike<T>): Promise<T> {
   const [awaitable, restore] = executeAsync(() => value);
+  const result = await awaitable;
+  restore();
+  return result;
+}
+
+async function preserveAsyncLocalStorageCallback<T>(
+  callback: () => T | PromiseLike<T>,
+): Promise<T> {
+  const [awaitable, restore] = executeAsync(async () => callback());
   const result = await awaitable;
   restore();
   return result;
@@ -109,6 +122,23 @@ test("keeps overlapping transformed runs isolated when they settle out of order"
 
   second.resolve("second done");
   await expect(secondResult).resolves.toBe("second");
+  expect(storage.getStore()).toBeUndefined();
+});
+
+test("restores the original frame after nested transformed async calls", async () => {
+  const storage = new AsyncLocalStorage<string>();
+
+  async function inner() {
+    await preserveAsyncLocalStorageCallback(() => Promise.resolve());
+    return storage.getStore();
+  }
+
+  async function outer() {
+    const innerStore = await preserveAsyncLocalStorageCallback(() => inner());
+    return [innerStore, storage.getStore()];
+  }
+
+  await expect(storage.run("inside", outer)).resolves.toEqual(["inside", "inside"]);
   expect(storage.getStore()).toBeUndefined();
 });
 

--- a/packages/vitest-plugin-rsc/src/async-local-storage.test.ts
+++ b/packages/vitest-plugin-rsc/src/async-local-storage.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import { resetAsyncLocalStorage } from "./async-local-storage";
+import { executeAsync, resetAsyncLocalStorage } from "./async-local-storage";
 import {
   AsyncLocalStorage,
   AsyncResource,
@@ -18,6 +18,13 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
+async function preserveAsyncLocalStorage<T>(value: T | PromiseLike<T>): Promise<T> {
+  const [awaitable, restore] = executeAsync(() => value);
+  const result = await awaitable;
+  restore();
+  return result;
+}
+
 test("scopes a store to the run callback", () => {
   const storage = new AsyncLocalStorage<string>();
 
@@ -27,15 +34,31 @@ test("scopes a store to the run callback", () => {
   expect(storage.getStore()).toBeUndefined();
 });
 
-test("keeps a store until the returned promise settles", async () => {
+test("keeps a store across a transformed await", async () => {
   const storage = new AsyncLocalStorage<string>();
 
   const result = await storage.run("inside", async () => {
-    await Promise.resolve();
+    await preserveAsyncLocalStorage(Promise.resolve());
     return storage.getStore();
   });
 
   expect(result).toBe("inside");
+  expect(storage.getStore()).toBeUndefined();
+});
+
+test("leaves a store while a transformed await is pending", async () => {
+  const storage = new AsyncLocalStorage<string>();
+  const pending = deferred<string>();
+
+  const result = storage.run("inside", async () => {
+    const value = await preserveAsyncLocalStorage(pending.promise);
+    return [value, storage.getStore()];
+  });
+
+  expect(storage.getStore()).toBeUndefined();
+
+  pending.resolve("done");
+  await expect(result).resolves.toEqual(["done", "inside"]);
   expect(storage.getStore()).toBeUndefined();
 });
 
@@ -64,20 +87,28 @@ test("does not preserve context for async work that is not returned", async () =
   expect(scheduledStore).toBeUndefined();
 });
 
-test("does not restore stale frames when overlapping runs settle out of order", async () => {
+test("keeps overlapping transformed runs isolated when they settle out of order", async () => {
   const storage = new AsyncLocalStorage<string>();
   const first = deferred<string>();
   const second = deferred<string>();
 
-  const firstResult = storage.run("first", () => first.promise);
-  const secondResult = storage.run("second", () => second.promise);
+  const firstResult = storage.run("first", async () => {
+    await preserveAsyncLocalStorage(first.promise);
+    return storage.getStore();
+  });
+  const secondResult = storage.run("second", async () => {
+    await preserveAsyncLocalStorage(second.promise);
+    return storage.getStore();
+  });
+
+  expect(storage.getStore()).toBeUndefined();
 
   first.resolve("first done");
-  await expect(firstResult).resolves.toBe("first done");
-  expect(storage.getStore()).toBe("second");
+  await expect(firstResult).resolves.toBe("first");
+  expect(storage.getStore()).toBeUndefined();
 
   second.resolve("second done");
-  await expect(secondResult).resolves.toBe("second done");
+  await expect(secondResult).resolves.toBe("second");
   expect(storage.getStore()).toBeUndefined();
 });
 
@@ -105,6 +136,114 @@ test("binds a callback to the current snapshot", () => {
 
   expect(bound()).toBe("inside");
   expect(storage.getStore()).toBe("outside");
+});
+
+test("keeps a stream result in context until it is consumed", async () => {
+  const storage = new AsyncLocalStorage<string>();
+  const seenStores: (string | undefined)[] = [];
+
+  const stream = storage.run(
+    "inside",
+    () =>
+      new ReadableStream<string>({
+        pull(controller) {
+          seenStores.push(storage.getStore());
+          controller.enqueue("chunk");
+          controller.close();
+        },
+      }),
+  );
+
+  expect(storage.getStore()).toBe("inside");
+
+  const reader = stream.getReader();
+  await expect(reader.read()).resolves.toEqual({ done: false, value: "chunk" });
+  expect((await reader.read()).done).toBe(true);
+  expect(seenStores).toEqual(["inside"]);
+  expect(storage.getStore()).toBeUndefined();
+});
+
+test("keeps a promised stream result in context until it is consumed", async () => {
+  const storage = new AsyncLocalStorage<string>();
+  const seenStores: (string | undefined)[] = [];
+
+  const stream = await storage.run("inside", async () => {
+    await preserveAsyncLocalStorage(Promise.resolve());
+    return new ReadableStream<string>({
+      pull(controller) {
+        seenStores.push(storage.getStore());
+        controller.enqueue("chunk");
+        controller.close();
+      },
+    });
+  });
+
+  expect(storage.getStore()).toBe("inside");
+
+  const reader = stream.getReader();
+  await expect(reader.read()).resolves.toEqual({ done: false, value: "chunk" });
+  expect((await reader.read()).done).toBe(true);
+  expect(seenStores).toEqual(["inside"]);
+  expect(storage.getStore()).toBeUndefined();
+});
+
+test("keeps nested run stores inside a stream result", async () => {
+  const first = new AsyncLocalStorage<string>();
+  const second = new AsyncLocalStorage<number>();
+  const seenStores: Array<[string | undefined, number | undefined]> = [];
+
+  const stream = first.run("first", () =>
+    second.run(
+      2,
+      () =>
+        new ReadableStream<string>({
+          pull(controller) {
+            seenStores.push([first.getStore(), second.getStore()]);
+            controller.enqueue("chunk");
+            controller.close();
+          },
+        }),
+    ),
+  );
+
+  expect(first.getStore()).toBe("first");
+  expect(second.getStore()).toBe(2);
+
+  const reader = stream.getReader();
+  await expect(reader.read()).resolves.toEqual({ done: false, value: "chunk" });
+  expect((await reader.read()).done).toBe(true);
+  expect(seenStores).toEqual([["first", 2]]);
+  expect(first.getStore()).toBeUndefined();
+  expect(second.getStore()).toBeUndefined();
+});
+
+test("keeps nested run stores inside a promised stream result", async () => {
+  const first = new AsyncLocalStorage<string>();
+  const second = new AsyncLocalStorage<number>();
+  const seenStores: Array<[string | undefined, number | undefined]> = [];
+
+  const stream = await first.run("first", () =>
+    second.run(2, async () => {
+      await preserveAsyncLocalStorage(Promise.resolve());
+      return new ReadableStream<string>({
+        pull(controller) {
+          seenStores.push([first.getStore(), second.getStore()]);
+          controller.enqueue("chunk");
+          controller.close();
+        },
+      });
+    }),
+  );
+
+  expect(first.getStore()).toBe("first");
+  expect(second.getStore()).toBe(2);
+
+  const reader = stream.getReader();
+  await expect(reader.read()).resolves.toEqual({ done: false, value: "chunk" });
+  expect((await reader.read()).done).toBe(true);
+  expect(seenStores).toEqual([["first", 2]]);
+  expect(first.getStore()).toBeUndefined();
+  expect(second.getStore()).toBeUndefined();
 });
 
 test("resets all stores", () => {

--- a/packages/vitest-plugin-rsc/src/async-local-storage.test.ts
+++ b/packages/vitest-plugin-rsc/src/async-local-storage.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import { executeAsync, resetAsyncLocalStorage } from "./async-local-storage";
+import { createAsyncLocalStorage, executeAsync, resetAsyncLocalStorage } from "./async-local-storage";
 import {
   AsyncLocalStorage,
   AsyncResource,
@@ -138,6 +138,17 @@ test("binds a callback to the current snapshot", () => {
   expect(storage.getStore()).toBe("outside");
 });
 
+test("reuses createAsyncLocalStorage keys for duplicate module callsites", () => {
+  const createStorageFromSameCallsite = () => createAsyncLocalStorage<string>();
+  const first = createStorageFromSameCallsite();
+  const second = createStorageFromSameCallsite();
+
+  const result = first.run("inside", () => second.getStore());
+
+  expect(result).toBe("inside");
+  expect(second.getStore()).toBeUndefined();
+});
+
 test("keeps a stream result in context until it is consumed", async () => {
   const storage = new AsyncLocalStorage<string>();
   const seenStores: (string | undefined)[] = [];
@@ -160,6 +171,29 @@ test("keeps a stream result in context until it is consumed", async () => {
   await expect(reader.read()).resolves.toEqual({ done: false, value: "chunk" });
   expect((await reader.read()).done).toBe(true);
   expect(seenStores).toEqual(["inside"]);
+  expect(storage.getStore()).toBeUndefined();
+});
+
+test("does not leave an active stream frame during a transformed await", async () => {
+  const storage = new AsyncLocalStorage<string>();
+
+  const stream = storage.run(
+    "inside",
+    () =>
+      new ReadableStream<string>({
+        pull(controller) {
+          controller.enqueue("chunk");
+          controller.close();
+        },
+      }),
+  );
+
+  await preserveAsyncLocalStorage(Promise.resolve());
+  expect(storage.getStore()).toBe("inside");
+
+  const reader = stream.getReader();
+  await expect(reader.read()).resolves.toEqual({ done: false, value: "chunk" });
+  expect((await reader.read()).done).toBe(true);
   expect(storage.getStore()).toBeUndefined();
 });
 

--- a/packages/vitest-plugin-rsc/src/async-local-storage.ts
+++ b/packages/vitest-plugin-rsc/src/async-local-storage.ts
@@ -1,13 +1,15 @@
 import { executeAsync as executeUnctxAsync } from "unctx";
 
 type RunCallback<R, TArgs extends unknown[]> = (...args: TArgs) => R;
-type StoreValues = Map<SequentialAsyncLocalStorage<unknown>, unknown>;
+type StoreKey = symbol | SequentialAsyncLocalStorage<unknown>;
+type StoreValues = Map<StoreKey, unknown>;
 type AsyncContextRestore = () => void;
 type AsyncContextLeave = () => AsyncContextRestore | undefined;
 type AsyncContextFrame = {
   stores: StoreValues;
   parent: AsyncContextFrame | undefined;
   active: boolean;
+  persistent: boolean;
   generation: number;
 };
 type AsyncContextState = {
@@ -51,10 +53,14 @@ function isContextBoundReadableStream(stream: ReadableStream<unknown>): boolean 
 }
 
 export class SequentialAsyncLocalStorage<Store> {
+  readonly #storeKey: StoreKey;
+
+  constructor(storeKey?: StoreKey) {
+    this.#storeKey = storeKey ?? (this as SequentialAsyncLocalStorage<unknown>);
+  }
+
   getStore(): Store | undefined {
-    return asyncContextState.currentFrame.stores.get(
-      this as SequentialAsyncLocalStorage<unknown>,
-    ) as Store | undefined;
+    return asyncContextState.currentFrame.stores.get(this.#storeKey) as Store | undefined;
   }
 
   run<R, TArgs extends unknown[]>(
@@ -64,14 +70,14 @@ export class SequentialAsyncLocalStorage<Store> {
   ): R {
     const previousFrame = asyncContextState.currentFrame;
     const frame = createFrame(previousFrame, previousFrame.stores);
-    frame.stores.set(this as SequentialAsyncLocalStorage<unknown>, store);
+    frame.stores.set(this.#storeKey, store);
     return runInFrame(frame, callback, args);
   }
 
   exit<R, TArgs extends unknown[]>(callback: RunCallback<R, TArgs>, ...args: TArgs): R {
     const previousFrame = asyncContextState.currentFrame;
     const frame = createFrame(previousFrame, previousFrame.stores);
-    frame.stores.delete(this as SequentialAsyncLocalStorage<unknown>);
+    frame.stores.delete(this.#storeKey);
     return runInFrame(frame, callback, args);
   }
 
@@ -82,7 +88,7 @@ export class SequentialAsyncLocalStorage<Store> {
       asyncContextState.currentFrame,
       asyncContextState.currentFrame.stores,
     );
-    frame.stores.set(this as SequentialAsyncLocalStorage<unknown>, store);
+    frame.stores.set(this.#storeKey, store);
     registerFrame(frame);
     asyncContextState.currentFrame = frame;
   }
@@ -93,7 +99,7 @@ export class SequentialAsyncLocalStorage<Store> {
       asyncContextState.currentFrame,
       asyncContextState.currentFrame.stores,
     );
-    frame.stores.delete(this as SequentialAsyncLocalStorage<unknown>);
+    frame.stores.delete(this.#storeKey);
     registerFrame(frame);
     asyncContextState.currentFrame = frame;
   }
@@ -123,7 +129,7 @@ export class SequentialAsyncLocalStorage<Store> {
 }
 
 export function createAsyncLocalStorage<Store>(): SequentialAsyncLocalStorage<Store> {
-  return new SequentialAsyncLocalStorage<Store>();
+  return new SequentialAsyncLocalStorage<Store>(getCreateAsyncLocalStorageKey());
 }
 
 export function bindSnapshot<T>(fn: T): T {
@@ -190,7 +196,9 @@ function runInFrame<R, TArgs extends unknown[]>(
       return result;
     }
 
+    frame.persistent = true;
     return withStreamLifecycle(result, () => {
+      frame.persistent = false;
       unregister();
       closeFrame(frame);
     }) as R;
@@ -220,8 +228,12 @@ function withAsyncResultLifecycle<R>(
           return value;
         }
 
+        frame.persistent = true;
         asyncContextState.currentFrame = frame;
-        return withStreamLifecycle(value, onFinally);
+        return withStreamLifecycle(value, () => {
+          frame.persistent = false;
+          onFinally();
+        });
       }
 
       onFinally();
@@ -312,6 +324,7 @@ function createFrame(
     stores: new Map(stores),
     parent,
     active: true,
+    persistent: false,
     generation: asyncContextState.resetGeneration,
   };
 }
@@ -321,6 +334,7 @@ function createRootFrame(generation: number): AsyncContextFrame {
     stores: new Map(),
     parent: undefined,
     active: true,
+    persistent: false,
     generation,
   };
 }
@@ -344,6 +358,7 @@ function suspendFrame(frame: AsyncContextFrame): void {
 function leaveFrame(frame: AsyncContextFrame): AsyncContextRestore | undefined {
   if (
     frame.generation !== asyncContextState.resetGeneration ||
+    frame.persistent ||
     !frame.active ||
     asyncContextState.currentFrame !== frame
   ) {
@@ -383,6 +398,52 @@ function getAsyncContextState(): AsyncContextState {
   }
 
   return globalScope.__vitest_plugin_rsc_async_context__;
+}
+
+function getCreateAsyncLocalStorageKey(): symbol {
+  const callsite = getCreateAsyncLocalStorageCallsite();
+  if (!callsite) return Symbol("vitest-plugin-rsc.async-local-storage");
+
+  const registry = getCreateAsyncLocalStorageKeyRegistry();
+  let key = registry.get(callsite);
+  if (!key) {
+    key = Symbol(callsite);
+    registry.set(callsite, key);
+  }
+
+  return key;
+}
+
+function getCreateAsyncLocalStorageCallsite(): string | undefined {
+  const stack = new Error().stack;
+  if (!stack) return;
+
+  for (const rawLine of stack.split("\n").slice(1)) {
+    const line = rawLine.trim();
+    if (
+      line.includes("getCreateAsyncLocalStorageCallsite") ||
+      line.includes("getCreateAsyncLocalStorageKey") ||
+      line.includes("createAsyncLocalStorage") ||
+      line.includes("vitest-plugin-rsc/async-local-storage") ||
+      /[/\\]async-local-storage-[^/\\]+\.js/.test(line)
+    ) {
+      continue;
+    }
+
+    return normalizeStorageCallsite(line);
+  }
+}
+
+function normalizeStorageCallsite(callsite: string): string {
+  return callsite.replace(/\?[^:)]+/g, "");
+}
+
+function getCreateAsyncLocalStorageKeyRegistry(): Map<string, symbol> {
+  const globalScope = globalThis as typeof globalThis & {
+    __vitest_plugin_rsc_async_storage_keys__?: Map<string, symbol>;
+  };
+
+  return (globalScope.__vitest_plugin_rsc_async_storage_keys__ ??= new Map());
 }
 
 function getUnctxAsyncHandlers(): Set<AsyncContextLeave> {

--- a/packages/vitest-plugin-rsc/src/async-local-storage.ts
+++ b/packages/vitest-plugin-rsc/src/async-local-storage.ts
@@ -44,12 +44,23 @@ function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
   );
 }
 
+function isCatchable(value: unknown): value is PromiseLike<unknown> & {
+  catch: (onRejected: (error: unknown) => never) => PromiseLike<unknown>;
+} {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "catch" in value &&
+    typeof value.catch === "function"
+  );
+}
+
 function isReadableStreamLike(value: unknown): value is ReadableStream<unknown> {
   return typeof ReadableStream !== "undefined" && value instanceof ReadableStream;
 }
 
 function isContextBoundReadableStream(stream: ReadableStream<unknown>): boolean {
-  return Boolean((stream as Record<symbol, unknown>)[contextBoundReadableStream]);
+  return Boolean((stream as unknown as Record<symbol, unknown>)[contextBoundReadableStream]);
 }
 
 export class SequentialAsyncLocalStorage<Store> {
@@ -151,7 +162,23 @@ export function withAsyncLocalStorageContext<T extends (...args: unknown[]) => u
   return fn;
 }
 
-export const executeAsync = executeUnctxAsync as <T>(callback: () => T) => [T, AsyncContextRestore];
+export function executeAsync<T>(callback: () => T): [T, AsyncContextRestore] {
+  const frame = asyncContextState.currentFrame;
+  const result = callback();
+  const restore = leaveCurrentAsyncContext(frame);
+
+  if (isCatchable(result)) {
+    return [
+      result.catch((error) => {
+        restore();
+        throw error;
+      }) as T,
+      restore,
+    ];
+  }
+
+  return [result, restore];
+}
 
 export function resetAsyncLocalStorage(): void {
   // Test cleanup must call this to drop request-local state that may be left
@@ -368,6 +395,17 @@ function leaveFrame(frame: AsyncContextFrame): AsyncContextRestore | undefined {
   suspendFrame(frame);
 
   return () => {
+    if (frame.generation !== asyncContextState.resetGeneration || !frame.active) return;
+
+    asyncContextState.currentFrame = frame;
+  };
+}
+
+function leaveCurrentAsyncContext(frame: AsyncContextFrame): AsyncContextRestore {
+  const [, restoreUnctx] = executeUnctxAsync(async () => undefined);
+
+  return () => {
+    restoreUnctx();
     if (frame.generation !== asyncContextState.resetGeneration || !frame.active) return;
 
     asyncContextState.currentFrame = frame;

--- a/packages/vitest-plugin-rsc/src/async-local-storage.ts
+++ b/packages/vitest-plugin-rsc/src/async-local-storage.ts
@@ -1,28 +1,37 @@
+import { executeAsync as executeUnctxAsync } from "unctx";
+
 type RunCallback<R, TArgs extends unknown[]> = (...args: TArgs) => R;
 type StoreValues = Map<SequentialAsyncLocalStorage<unknown>, unknown>;
+type AsyncContextRestore = () => void;
+type AsyncContextLeave = () => AsyncContextRestore | undefined;
 type AsyncContextFrame = {
   stores: StoreValues;
   parent: AsyncContextFrame | undefined;
   active: boolean;
   generation: number;
 };
+type AsyncContextState = {
+  resetGeneration: number;
+  rootFrame: AsyncContextFrame;
+  currentFrame: AsyncContextFrame;
+  asyncContextHandlers: Set<AsyncContextLeave>;
+};
 
 // This is a small WinterCG-style AsyncLocalStorage shim for browser tests.
 // It intentionally does not patch Promise, timers, events, or React's scheduler.
-// Context is preserved while a `run()`/snapshot callback is executing and until
-// the promise returned by that callback settles.
-//
-// The current frame is module-global, so tests that rely on this shim must run
-// sequentially within a browser worker. Do not use `test.concurrent` for cases
-// that share this async context surface.
+// Instead, vitestPluginRSC() applies an unctx-powered transform to async
+// callbacks passed to AsyncLocalStorage boundaries. The transformed awaits call
+// executeAsync() below so this shim can leave the current frame while an async
+// continuation is suspended, then restore it before the continuation resumes.
 //
 // The frame chain keeps overlapping returned promises from restoring stale
 // context if they settle out of order.
 // Cleanup invalidates older async finalizers so a previous test cannot
 // restore a stale frame after the stores have been reset.
-let resetGeneration = 0;
-let rootFrame: AsyncContextFrame = createFrame(undefined, new Map());
-let currentFrame: AsyncContextFrame = rootFrame;
+const asyncContextState = getAsyncContextState();
+const contextBoundReadableStream = Symbol.for(
+  "vitest-plugin-rsc.async-local-storage.contextBoundReadableStream",
+);
 
 function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
   return (
@@ -33,24 +42,19 @@ function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
   );
 }
 
-function withFinally<R>(result: R, onFinally: () => void): R {
-  return (result as PromiseLike<unknown>).then(
-    (value) => {
-      onFinally();
-      return value;
-    },
-    (error) => {
-      onFinally();
-      throw error;
-    },
-  ) as R;
+function isReadableStreamLike(value: unknown): value is ReadableStream<unknown> {
+  return typeof ReadableStream !== "undefined" && value instanceof ReadableStream;
+}
+
+function isContextBoundReadableStream(stream: ReadableStream<unknown>): boolean {
+  return Boolean((stream as Record<symbol, unknown>)[contextBoundReadableStream]);
 }
 
 export class SequentialAsyncLocalStorage<Store> {
   getStore(): Store | undefined {
-    return currentFrame.stores.get(this as SequentialAsyncLocalStorage<unknown>) as
-      | Store
-      | undefined;
+    return asyncContextState.currentFrame.stores.get(
+      this as SequentialAsyncLocalStorage<unknown>,
+    ) as Store | undefined;
   }
 
   run<R, TArgs extends unknown[]>(
@@ -58,66 +62,40 @@ export class SequentialAsyncLocalStorage<Store> {
     callback: RunCallback<R, TArgs>,
     ...args: TArgs
   ): R {
-    const previousFrame = currentFrame;
+    const previousFrame = asyncContextState.currentFrame;
     const frame = createFrame(previousFrame, previousFrame.stores);
     frame.stores.set(this as SequentialAsyncLocalStorage<unknown>, store);
-    currentFrame = frame;
-
-    let result: R;
-    try {
-      result = callback(...args);
-    } catch (error) {
-      closeFrame(frame);
-      throw error;
-    }
-
-    if (isPromiseLike(result)) {
-      return withFinally(result, () => {
-        closeFrame(frame);
-      });
-    }
-
-    closeFrame(frame);
-    return result;
+    return runInFrame(frame, callback, args);
   }
 
   exit<R, TArgs extends unknown[]>(callback: RunCallback<R, TArgs>, ...args: TArgs): R {
-    const previousFrame = currentFrame;
+    const previousFrame = asyncContextState.currentFrame;
     const frame = createFrame(previousFrame, previousFrame.stores);
     frame.stores.delete(this as SequentialAsyncLocalStorage<unknown>);
-    currentFrame = frame;
-
-    let result: R;
-    try {
-      result = callback(...args);
-    } catch (error) {
-      closeFrame(frame);
-      throw error;
-    }
-
-    if (isPromiseLike(result)) {
-      return withFinally(result, () => {
-        closeFrame(frame);
-      });
-    }
-
-    closeFrame(frame);
-    return result;
+    return runInFrame(frame, callback, args);
   }
 
   enterWith(store: Store): void {
     // Provided for compatibility with Node/Next consumers. WinterCG's portable
     // subset avoids enterWith/disable, but Next still probes for these methods.
-    const frame = createFrame(currentFrame, currentFrame.stores);
+    const frame = createFrame(
+      asyncContextState.currentFrame,
+      asyncContextState.currentFrame.stores,
+    );
     frame.stores.set(this as SequentialAsyncLocalStorage<unknown>, store);
-    currentFrame = frame;
+    registerFrame(frame);
+    asyncContextState.currentFrame = frame;
   }
 
   disable(): void {
     // Compatibility-only counterpart to enterWith().
-    const frame = createFrame(currentFrame, currentFrame.stores);
+    const frame = createFrame(
+      asyncContextState.currentFrame,
+      asyncContextState.currentFrame.stores,
+    );
     frame.stores.delete(this as SequentialAsyncLocalStorage<unknown>);
-    currentFrame = frame;
+    registerFrame(frame);
+    asyncContextState.currentFrame = frame;
   }
 
   static bind<T extends (...args: unknown[]) => unknown>(fn: T): T {
@@ -127,37 +105,20 @@ export class SequentialAsyncLocalStorage<Store> {
 
   static snapshot(): <R, TArgs extends unknown[]>(fn: RunCallback<R, TArgs>, ...args: TArgs) => R {
     const snapshot = SequentialAsyncLocalStorage.#snapshotStores();
-    const snapshotGeneration = resetGeneration;
+    const snapshotGeneration = asyncContextState.resetGeneration;
 
     return <R, TArgs extends unknown[]>(fn: RunCallback<R, TArgs>, ...args: TArgs): R => {
       // Snapshots captured before test cleanup are ignored so delayed callbacks
       // from one test cannot re-enter the previous test's request context.
-      if (snapshotGeneration !== resetGeneration) return fn(...args);
+      if (snapshotGeneration !== asyncContextState.resetGeneration) return fn(...args);
 
-      const frame = createFrame(currentFrame, snapshot);
-      currentFrame = frame;
-
-      let result: R;
-      try {
-        result = fn(...args);
-      } catch (error) {
-        closeFrame(frame);
-        throw error;
-      }
-
-      if (isPromiseLike(result)) {
-        return withFinally(result, () => {
-          closeFrame(frame);
-        });
-      }
-
-      closeFrame(frame);
-      return result;
+      const frame = createFrame(asyncContextState.currentFrame, snapshot);
+      return runInFrame(frame, fn, args);
     };
   }
 
   static #snapshotStores(): StoreValues {
-    return new Map(currentFrame.stores);
+    return new Map(asyncContextState.currentFrame.stores);
   }
 }
 
@@ -177,14 +138,170 @@ export function createSnapshot(): <R, TArgs extends unknown[]>(
   return SequentialAsyncLocalStorage.snapshot();
 }
 
+export function withAsyncLocalStorageContext<T extends (...args: unknown[]) => unknown>(
+  fn: T,
+  _transformed?: true,
+): T {
+  return fn;
+}
+
+export const executeAsync = executeUnctxAsync as <T>(callback: () => T) => [T, AsyncContextRestore];
+
 export function resetAsyncLocalStorage(): void {
   // Test cleanup must call this to drop request-local state that may be left
   // behind by a failed render, an unawaited promise, or other hanging work.
   // Bumping the generation also prevents delayed promise finalizers and old
   // snapshots from re-entering a previous test's frame.
-  resetGeneration++;
-  rootFrame = createFrame(undefined, new Map());
-  currentFrame = rootFrame;
+  asyncContextState.resetGeneration++;
+  asyncContextState.asyncContextHandlers.clear();
+  asyncContextState.rootFrame = createRootFrame(asyncContextState.resetGeneration);
+  asyncContextState.currentFrame = asyncContextState.rootFrame;
+}
+
+function runInFrame<R, TArgs extends unknown[]>(
+  frame: AsyncContextFrame,
+  callback: RunCallback<R, TArgs>,
+  args: TArgs,
+): R {
+  asyncContextState.currentFrame = frame;
+  const unregister = registerFrame(frame);
+
+  let result: R;
+  try {
+    result = callback(...args);
+  } catch (error) {
+    unregister();
+    closeFrame(frame);
+    throw error;
+  }
+
+  if (isPromiseLike(result)) {
+    suspendFrame(frame);
+    return withAsyncResultLifecycle(result, frame, () => {
+      unregister();
+      closeFrame(frame);
+    });
+  }
+
+  if (isReadableStreamLike(result)) {
+    if (frame.stores.size === 0 || isContextBoundReadableStream(result)) {
+      unregister();
+      closeFrame(frame);
+      return result;
+    }
+
+    return withStreamLifecycle(result, () => {
+      unregister();
+      closeFrame(frame);
+    }) as R;
+  }
+
+  unregister();
+  closeFrame(frame);
+  return result;
+}
+
+function registerFrame(frame: AsyncContextFrame): () => void {
+  const handler = () => leaveFrame(frame);
+  asyncContextState.asyncContextHandlers.add(handler);
+  return () => asyncContextState.asyncContextHandlers.delete(handler);
+}
+
+function withAsyncResultLifecycle<R>(
+  result: R,
+  frame: AsyncContextFrame,
+  onFinally: () => void,
+): R {
+  return (result as PromiseLike<unknown>).then(
+    (value) => {
+      if (isReadableStreamLike(value)) {
+        if (frame.stores.size === 0 || isContextBoundReadableStream(value)) {
+          onFinally();
+          return value;
+        }
+
+        asyncContextState.currentFrame = frame;
+        return withStreamLifecycle(value, onFinally);
+      }
+
+      onFinally();
+      return value;
+    },
+    (error) => {
+      onFinally();
+      throw error;
+    },
+  ) as R;
+}
+
+function withStreamLifecycle<T>(
+  stream: ReadableStream<T>,
+  onFinally: () => void,
+): ReadableStream<T> {
+  const reader = stream.getReader();
+  let closed = false;
+
+  const close = () => {
+    if (closed) return;
+
+    closed = true;
+    onFinally();
+  };
+
+  const wrappedStream = new ReadableStream<T>({
+    pull(controller) {
+      let next: Promise<ReadableStreamReadResult<T>>;
+      try {
+        next = reader.read();
+      } catch (error) {
+        close();
+        controller.error(error);
+        throw error;
+      }
+
+      return next.then(
+        (result) => {
+          if (result.done) {
+            close();
+            controller.close();
+            return;
+          }
+
+          controller.enqueue(result.value);
+        },
+        (error) => {
+          close();
+          controller.error(error);
+          throw error;
+        },
+      );
+    },
+    cancel(reason) {
+      let cancelResult: Promise<void>;
+      try {
+        cancelResult = reader.cancel(reason);
+      } catch (error) {
+        close();
+        throw error;
+      }
+
+      return cancelResult.then(
+        () => {
+          close();
+        },
+        (error) => {
+          close();
+          throw error;
+        },
+      );
+    },
+  });
+
+  Object.defineProperty(wrappedStream, contextBoundReadableStream, {
+    value: true,
+  });
+
+  return wrappedStream;
 }
 
 function createFrame(
@@ -195,15 +312,51 @@ function createFrame(
     stores: new Map(stores),
     parent,
     active: true,
-    generation: resetGeneration,
+    generation: asyncContextState.resetGeneration,
+  };
+}
+
+function createRootFrame(generation: number): AsyncContextFrame {
+  return {
+    stores: new Map(),
+    parent: undefined,
+    active: true,
+    generation,
   };
 }
 
 function closeFrame(frame: AsyncContextFrame): void {
   frame.active = false;
-  if (frame.generation !== resetGeneration || currentFrame !== frame) return;
+  suspendFrame(frame);
+}
 
-  currentFrame = nearestActiveFrame(frame.parent);
+function suspendFrame(frame: AsyncContextFrame): void {
+  if (
+    frame.generation !== asyncContextState.resetGeneration ||
+    asyncContextState.currentFrame !== frame
+  ) {
+    return;
+  }
+
+  asyncContextState.currentFrame = nearestActiveFrame(frame.parent);
+}
+
+function leaveFrame(frame: AsyncContextFrame): AsyncContextRestore | undefined {
+  if (
+    frame.generation !== asyncContextState.resetGeneration ||
+    !frame.active ||
+    asyncContextState.currentFrame !== frame
+  ) {
+    return;
+  }
+
+  suspendFrame(frame);
+
+  return () => {
+    if (frame.generation !== asyncContextState.resetGeneration || !frame.active) return;
+
+    asyncContextState.currentFrame = frame;
+  };
 }
 
 function nearestActiveFrame(frame: AsyncContextFrame | undefined): AsyncContextFrame {
@@ -211,5 +364,31 @@ function nearestActiveFrame(frame: AsyncContextFrame | undefined): AsyncContextF
     frame = frame.parent;
   }
 
-  return frame ?? rootFrame;
+  return frame ?? asyncContextState.rootFrame;
+}
+
+function getAsyncContextState(): AsyncContextState {
+  const globalScope = globalThis as typeof globalThis & {
+    __vitest_plugin_rsc_async_context__?: AsyncContextState;
+  };
+
+  if (!globalScope.__vitest_plugin_rsc_async_context__) {
+    const rootFrame = createRootFrame(0);
+    globalScope.__vitest_plugin_rsc_async_context__ = {
+      resetGeneration: 0,
+      rootFrame,
+      currentFrame: rootFrame,
+      asyncContextHandlers: getUnctxAsyncHandlers(),
+    };
+  }
+
+  return globalScope.__vitest_plugin_rsc_async_context__;
+}
+
+function getUnctxAsyncHandlers(): Set<AsyncContextLeave> {
+  const globalScope = globalThis as typeof globalThis & {
+    __unctx_async_handlers__?: Set<AsyncContextLeave>;
+  };
+
+  return (globalScope.__unctx_async_handlers__ ??= new Set());
 }

--- a/packages/vitest-plugin-rsc/src/index.ts
+++ b/packages/vitest-plugin-rsc/src/index.ts
@@ -1,6 +1,7 @@
 import { type Plugin, type ViteDevServer } from "vite";
 import { vitePluginRscMinimal } from "@vitejs/plugin-rsc/plugin";
 import { createReactClientCoveragePlugin } from "./coverage";
+import { createAsyncLocalStorageTransformPlugin } from "./async-local-storage-transform";
 
 const reactClientWebSocketInfoPath = "/@vite/react-client-runner-websocket";
 const reactClientWebSocketQuery = "vitest-plugin-rsc-react-client";
@@ -135,6 +136,7 @@ export function vitestPluginRSC(): Plugin[] {
         ];
       },
     },
+    createAsyncLocalStorageTransformPlugin(),
     createReactClientCoveragePlugin(),
   ];
 }

--- a/packages/vitest-plugin-rsc/src/nextjs/plugin.ts
+++ b/packages/vitest-plugin-rsc/src/nextjs/plugin.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import type { Alias, Plugin, UserConfig } from "vite";
 
 const supportedEdgeNativeModules = ["buffer", "events", "assert", "util"] as const;
+const nextAsyncLocalStorageReplacementId = "vitest-plugin-rsc/async-local-storage";
 // Begin copy: Next.js ACTION_ID_EXPECTED_LENGTH
 // Source: https://github.com/vercel/next.js/blob/4588a7354283f97e2124e3d82f55733ca4eb9373/packages/next/src/server/app-render/action-handler.ts#L1372-L1375
 const ACTION_ID_EXPECTED_LENGTH = 42;
@@ -142,6 +143,7 @@ function createNextEdgeNativeAliases(root: string): Alias[] {
 function createOptimizeDepsResolveAliases(
   edgeNativeAliases: Alias[],
   aliases: Record<string, string>,
+  nextAsyncLocalStorageAliases: Record<string, string>,
 ) {
   return {
     ...Object.fromEntries(
@@ -149,7 +151,15 @@ function createOptimizeDepsResolveAliases(
         .filter((alias): alias is Alias & { find: string } => typeof alias.find === "string")
         .map((alias) => [alias.find, alias.replacement]),
     ),
+    ...nextAsyncLocalStorageAliases,
     ...aliases,
+  };
+}
+
+function createNextAsyncLocalStorageAliases(replacement: string): Record<string, string> {
+  return {
+    "next/dist/server/app-render/async-local-storage": replacement,
+    "next/dist/server/app-render/async-local-storage.js": replacement,
   };
 }
 
@@ -178,6 +188,37 @@ function useNextCompiledOpenTelemetryApi(root: string): Plugin {
       return replacement;
     },
   };
+}
+
+function useVitestAsyncLocalStorageForNext(root = process.cwd()): Plugin {
+  const replacement =
+    tryResolveFromProject(root, nextAsyncLocalStorageReplacementId) ??
+    nextAsyncLocalStorageReplacementId;
+  const aliases = createNextAsyncLocalStorageAliases(replacement);
+
+  return {
+    name: "next-rsc-async-local-storage",
+    enforce: "pre",
+    async resolveId(source, importer, options) {
+      const resolvedReplacement =
+        aliases[source] ??
+        (isNextAppRenderAsyncLocalStorageImport(source, importer) ? replacement : undefined);
+
+      if (!resolvedReplacement) return;
+
+      return this.resolve(resolvedReplacement, importer, {
+        ...options,
+        skipSelf: true,
+      });
+    },
+  };
+}
+
+function isNextAppRenderAsyncLocalStorageImport(source: string, importer?: string) {
+  return (
+    (source === "./async-local-storage" || source === "./async-local-storage.js") &&
+    Boolean(importer && /[/\\]next[/\\]dist[/\\]server[/\\]app-render[/\\]/.test(importer))
+  );
 }
 
 function useVitestServerReferenceInfo(root = process.cwd()): Plugin {
@@ -292,6 +333,7 @@ function rewriteTypeofWindowChecks(code: string) {
 
 export function vitestPluginNext(): Plugin[] {
   return [
+    useVitestAsyncLocalStorageForNext(),
     useVitestServerReferenceInfo(),
     treatNextInternalsAsServerInRsc(),
     appRouterApiPlugin("client", true),
@@ -304,6 +346,10 @@ export function vitestPluginNext(): Plugin[] {
         const rscAppRouterAliases = createAppRouterApiAliasesFromNext(root, true);
         const reactClientAppRouterAliases = createAppRouterApiAliasesFromNext(root, false);
         const reactServerDomWebpackAliases = createReactServerDomWebpackAliases(root);
+        const nextAsyncLocalStorageAliases = createNextAsyncLocalStorageAliases(
+          tryResolveFromProject(root, nextAsyncLocalStorageReplacementId) ??
+            nextAsyncLocalStorageReplacementId,
+        );
 
         return {
           define: {
@@ -313,6 +359,10 @@ export function vitestPluginNext(): Plugin[] {
           resolve: {
             alias: [
               ...edgeNativeAliases,
+              ...Object.entries(nextAsyncLocalStorageAliases).map(([find, replacement]) => ({
+                find,
+                replacement,
+              })),
               {
                 find: "@vercel/turbopack-ecmascript-runtime/browser/dev/hmr-client/hmr-client.ts",
                 replacement: "next/dist/client/dev/noop-turbopack-hmr",
@@ -338,7 +388,6 @@ export function vitestPluginNext(): Plugin[] {
                   "next/dist/compiled/@edge-runtime/cookies/index.js",
                   "next/dist/server/node-environment-baseline.js",
                   "next/dist/server/app-render/action-async-storage.external.js",
-                  "next/dist/server/app-render/async-local-storage.js",
                   "next/dist/server/app-render/work-async-storage.external.js",
                   "next/dist/server/app-render/work-unit-async-storage.external.js",
                   "next/dist/server/async-storage/request-store.js",
@@ -405,13 +454,18 @@ export function vitestPluginNext(): Plugin[] {
                 needsInterop: ["next/cache"],
                 rolldownOptions: {
                   plugins: [
+                    useVitestAsyncLocalStorageForNext(root),
                     useVitestServerReferenceInfo(root),
                     treatNextInternalsAsServerInRsc(),
                     useNextCompiledOpenTelemetryApi(root),
                   ],
                   resolve: {
                     alias: {
-                      ...createOptimizeDepsResolveAliases(edgeNativeAliases, rscAppRouterAliases),
+                      ...createOptimizeDepsResolveAliases(
+                        edgeNativeAliases,
+                        rscAppRouterAliases,
+                        nextAsyncLocalStorageAliases,
+                      ),
                       "react-server-dom-webpack/client": reactServerDomWebpackAliases.edge,
                     },
                   },
@@ -477,6 +531,7 @@ export function vitestPluginNext(): Plugin[] {
                 ],
                 rolldownOptions: {
                   plugins: [
+                    useVitestAsyncLocalStorageForNext(root),
                     useVitestServerReferenceInfo(root),
                     useNextCompiledOpenTelemetryApi(root),
                   ],
@@ -485,6 +540,7 @@ export function vitestPluginNext(): Plugin[] {
                       ...createOptimizeDepsResolveAliases(
                         edgeNativeAliases,
                         reactClientAppRouterAliases,
+                        nextAsyncLocalStorageAliases,
                       ),
                       "react-server-dom-webpack/client": reactServerDomWebpackAliases.browser,
                       "react-server-dom-webpack/client.browser":

--- a/packages/vitest-plugin-rsc/src/nextjs/request-context.ts
+++ b/packages/vitest-plugin-rsc/src/nextjs/request-context.ts
@@ -162,16 +162,12 @@ export async function createNextRequestContext({
       // Adaptation: the generic test harness chooses the phase for render vs
       // action callbacks.
       requestStore.phase = phase === "action-render" ? "render" : phase;
-      // Next uses nested `.run(...)` calls here. Our browser AsyncLocalStorage
-      // shim currently closes a `.run(...)` frame once the direct callback
-      // result settles, while React's RSC stream can continue rendering later
-      // during stream consumption. Keep the request stores ambient for the
-      // mounted test root and rely on test cleanup to reset the global shim.
-      workAsyncStorage.enterWith(workStore as never);
-      actionAsyncStorage.enterWith({ isAction: phase !== "render" });
-      workUnitAsyncStorage.enterWith(requestStore as never);
+      return workAsyncStorage.run(workStore as never, () =>
+        actionAsyncStorage.run({ isAction: phase !== "render" }, () =>
+          workUnitAsyncStorage.run(requestStore as never, callback),
+        ),
+      );
       // End copy
-      return callback();
     },
     async completeAction(options: { forceRender?: boolean } = {}) {
       const headers = new Headers(responseHeaders);

--- a/packages/vitest-plugin-rsc/src/nextjs/testing-library.tsx
+++ b/packages/vitest-plugin-rsc/src/nextjs/testing-library.tsx
@@ -22,6 +22,7 @@ import {
   type RenderConfiguration,
 } from "../testing-library";
 import type { FetchRsc, RscPayload, TestingLibraryClientRoot } from "../testing-library-client";
+import { bindSnapshot, createSnapshot } from "../async-local-storage";
 import { importReactClient } from "../utilts";
 import * as ReactServer from "@vitejs/plugin-rsc/react/rsc";
 import { NextRouter } from "vitest-plugin-rsc/nextjs/client";
@@ -101,6 +102,7 @@ export async function renderServer(
   rerender: (ui: ReactNode) => Promise<void>;
   asFragment: () => DocumentFragment;
 }> {
+  const runInRenderSnapshot = createSnapshot();
   container ??= baseElement.appendChild(document.createElement("div"));
 
   let root: TestingLibraryClientRoot;
@@ -122,7 +124,7 @@ export async function renderServer(
       return createNextRouterInitialTree(serverRoot, requestUrl, requestRoute);
     }
 
-    const fetchRsc: FetchRsc = async (actionRequest) => {
+    const fetchRsc: FetchRsc = bindSnapshot(async (actionRequest) => {
       let returnValue: unknown | undefined;
       let temporaryReferences: unknown | undefined;
       if (actionRequest) {
@@ -132,19 +134,24 @@ export async function renderServer(
           temporaryReferences,
         });
         const action = await ReactServer.loadServerAction(id);
-        returnValue = await requestContext.run("action", () => action.apply(null, args));
+        returnValue = await runInRenderSnapshot(() =>
+          requestContext.run("action", () => action.apply(null, args)),
+        );
       }
       const rscPayload: RscPayload = {
         root: await prepareServerRoot(),
         returnValue,
       };
       const rscOptions = { temporaryReferences };
-      return requestContext.run(actionRequest ? "action-render" : "render", () =>
-        ReactServer.renderToReadableStream<RscPayload>(rscPayload, rscOptions),
+      const stream = runInRenderSnapshot(() =>
+        requestContext.run(actionRequest ? "action-render" : "render", () =>
+          ReactServer.renderToReadableStream<RscPayload>(rscPayload, rscOptions),
+        ),
       );
-    };
+      return stream;
+    });
 
-    const fetchNextRsc: FetchNextRsc = async (request) => {
+    const fetchNextRsc: FetchNextRsc = bindSnapshot(async (request) => {
       if (request.requestType === "next-action") {
         let returnValue: unknown | undefined;
         const temporaryReferences = ReactServer.createTemporaryReferenceSet();
@@ -160,7 +167,9 @@ export async function renderServer(
         }
         const args = await ReactServer.decodeReply(request.reply, { temporaryReferences });
         try {
-          returnValue = await requestContext.run("action", () => action.apply(null, args));
+          returnValue = await runInRenderSnapshot(() =>
+            requestContext.run("action", () => action.apply(null, args)),
+          );
         } catch (error) {
           if (isRedirectError(error)) {
             const actionResult = await requestContext.completeAction({ forceRender: true });
@@ -186,8 +195,10 @@ export async function renderServer(
               true,
               request.routerState,
             );
-            const stream = await requestContext.run("action-render", () =>
-              ReactServer.renderToReadableStream(actionResponse, { temporaryReferences }),
+            const stream = runInRenderSnapshot(() =>
+              requestContext.run("action-render", () =>
+                ReactServer.renderToReadableStream(actionResponse, { temporaryReferences }),
+              ),
             );
             const responseHeaders = new Headers(actionResult.headers);
             responseHeaders.set("content-type", RSC_CONTENT_TYPE_HEADER);
@@ -204,8 +215,10 @@ export async function renderServer(
           actionResult.shouldRender,
           request.routerState,
         );
-        const stream = await requestContext.run("action-render", () =>
-          ReactServer.renderToReadableStream(actionResponse, { temporaryReferences }),
+        const stream = runInRenderSnapshot(() =>
+          requestContext.run("action-render", () =>
+            ReactServer.renderToReadableStream(actionResponse, { temporaryReferences }),
+          ),
         );
         const responseHeaders = new Headers(actionResult.headers);
         responseHeaders.set("content-type", RSC_CONTENT_TYPE_HEADER);
@@ -220,13 +233,13 @@ export async function renderServer(
         request.url,
         request.routerState,
       );
-      const stream = await requestContext.run("render", () =>
-        ReactServer.renderToReadableStream(routeResponse),
+      const stream = runInRenderSnapshot(() =>
+        requestContext.run("render", () => ReactServer.renderToReadableStream(routeResponse)),
       );
       return new Response(stream, {
         headers: { "content-type": RSC_CONTENT_TYPE_HEADER },
       });
-    };
+    });
 
     const serverActionCaller = config.nextRscRequestsViaMsw
       ? nextClient.createServerActionCaller({ fetchRsc: fetchNextRsc })

--- a/packages/vitest-plugin-rsc/src/nextjs/testing-library.tsx
+++ b/packages/vitest-plugin-rsc/src/nextjs/testing-library.tsx
@@ -199,7 +199,7 @@ export async function renderServer(
               requestContext.run("action-render", () =>
                 ReactServer.renderToReadableStream(actionResponse, { temporaryReferences }),
               ),
-            );
+            ) as ReadableStream<Uint8Array>;
             const responseHeaders = new Headers(actionResult.headers);
             responseHeaders.set("content-type", RSC_CONTENT_TYPE_HEADER);
             return new Response(stream, {
@@ -219,7 +219,7 @@ export async function renderServer(
           requestContext.run("action-render", () =>
             ReactServer.renderToReadableStream(actionResponse, { temporaryReferences }),
           ),
-        );
+        ) as ReadableStream<Uint8Array>;
         const responseHeaders = new Headers(actionResult.headers);
         responseHeaders.set("content-type", RSC_CONTENT_TYPE_HEADER);
         return new Response(stream, {
@@ -235,7 +235,7 @@ export async function renderServer(
       );
       const stream = runInRenderSnapshot(() =>
         requestContext.run("render", () => ReactServer.renderToReadableStream(routeResponse)),
-      );
+      ) as ReadableStream<Uint8Array>;
       return new Response(stream, {
         headers: { "content-type": RSC_CONTENT_TYPE_HEADER },
       });

--- a/packages/vitest-plugin-rsc/src/testing-library.tsx
+++ b/packages/vitest-plugin-rsc/src/testing-library.tsx
@@ -1,6 +1,6 @@
 import type { Container, RootOptions } from "react-dom/client";
 import type { JSXElementConstructor, ReactNode } from "react";
-import { resetAsyncLocalStorage } from "./async-local-storage";
+import { bindSnapshot, resetAsyncLocalStorage } from "./async-local-storage";
 import { importReactClient } from "./utilts";
 import type { FetchRsc, RscPayload, TestingLibraryClientRoot } from "./testing-library-client";
 import * as ReactServer from "@vitejs/plugin-rsc/react/rsc";
@@ -38,7 +38,7 @@ export async function renderServer(
   let root: TestingLibraryClientRoot;
 
   if (!mountedContainers.has(container)) {
-    const fetchRsc: FetchRsc = async (actionRequest) => {
+    const fetchRsc: FetchRsc = bindSnapshot(async (actionRequest) => {
       let returnValue: unknown | undefined;
       let temporaryReferences: unknown | undefined;
       if (actionRequest) {
@@ -61,7 +61,7 @@ export async function renderServer(
       const rscOptions = { temporaryReferences };
       const stream = ReactServer.renderToReadableStream<RscPayload>(rscPayload, rscOptions);
       return stream;
-    };
+    });
     root = await client.createTestingLibraryClientRoot({
       container,
       config,

--- a/playground/nextjs-no-msw-demo/vitest.config.ts
+++ b/playground/nextjs-no-msw-demo/vitest.config.ts
@@ -3,6 +3,9 @@ import { defineConfig } from "vitest/config";
 import { vitestPluginRSC } from "vitest-plugin-rsc";
 import { vitestPluginNext } from "vitest-plugin-rsc/nextjs/plugin";
 
+// oxlint-disable-next-line no-process-env
+const browserApiPort = Number(process.env.VITEST_BROWSER_API_PORT ?? 64125);
+
 export default defineConfig({
   plugins: [vitestPluginRSC(), vitestPluginNext()],
   resolve: {
@@ -10,6 +13,7 @@ export default defineConfig({
   },
   optimizeDeps: {
     include: [
+      "vitest-plugin-rsc > unctx",
       "next/dist/client/components/http-access-fallback/http-access-fallback.js",
       "next/dist/client/components/redirect-error.js",
       "next/dist/client/components/redirect-status-code.js",
@@ -18,6 +22,7 @@ export default defineConfig({
   },
   test: {
     browser: {
+      api: browserApiPort,
       enabled: true,
       headless: true,
       provider: playwright(),

--- a/playground/nextjs-notes-demo/app/next-async-storage-concurrent.test.ts
+++ b/playground/nextjs-notes-demo/app/next-async-storage-concurrent.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "vitest";
+import { headers } from "next/headers";
+import { createNextRequestContext } from "vitest-plugin-rsc/nextjs/request-context";
+
+const startTogether = createBarrier(2);
+const firstEntered = deferred<void>();
+const secondEntered = deferred<void>();
+
+test.concurrent("keeps the first Next request async storage isolated across awaits", async () => {
+  await startTogether();
+
+  const requestContext = await createNextRequestContext({
+    url: "/concurrent-first",
+    headers: {
+      "x-test-request": "first",
+      cookie: "flash=first",
+    },
+  });
+
+  await requestContext.run("render", async () => {
+    expect((await headers()).get("x-test-request")).toBe("first");
+    firstEntered.resolve();
+    await secondEntered.promise;
+    await Promise.resolve();
+    expect((await headers()).get("x-test-request")).toBe("first");
+  });
+});
+
+test.concurrent("keeps the second Next request async storage isolated across awaits", async () => {
+  await startTogether();
+  await firstEntered.promise;
+
+  const requestContext = await createNextRequestContext({
+    url: "/concurrent-second",
+    headers: {
+      "x-test-request": "second",
+      cookie: "flash=second",
+    },
+  });
+
+  await requestContext.run("render", async () => {
+    expect((await headers()).get("x-test-request")).toBe("second");
+    secondEntered.resolve();
+    await Promise.resolve();
+    expect((await headers()).get("x-test-request")).toBe("second");
+  });
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolve_) => {
+    resolve = resolve_;
+  });
+
+  return { promise, resolve };
+}
+
+function createBarrier(count: number) {
+  let waiting = 0;
+  const ready = deferred<void>();
+
+  return () => {
+    waiting++;
+    if (waiting === count) {
+      ready.resolve();
+    }
+    return ready.promise;
+  };
+}

--- a/playground/nextjs-notes-demo/vitest.config.ts
+++ b/playground/nextjs-notes-demo/vitest.config.ts
@@ -11,6 +11,9 @@ process.env.LAUNCH_EDITOR = "/usr/bin/true";
 // oxlint-disable-next-line no-process-env
 const maxWorkers = process.env.CI ? undefined : 4;
 
+// oxlint-disable-next-line no-process-env
+const browserApiPort = Number(process.env.VITEST_BROWSER_API_PORT ?? 64124);
+
 export default defineConfig({
   envPrefix: ["VITE_", "CI"],
   resolve: {
@@ -22,6 +25,7 @@ export default defineConfig({
   },
   optimizeDeps: {
     include: [
+      "vitest-plugin-rsc > unctx",
       "next/dist/client/components/http-access-fallback/http-access-fallback.js",
       "next/dist/client/components/redirect-error.js",
       "next/dist/client/components/redirect-status-code.js",
@@ -54,6 +58,7 @@ export default defineConfig({
           include: ["**/*.test.{ts,tsx}"],
           exclude: ["**/*.node.test.{ts,tsx}", "node_modules"],
           browser: {
+            api: browserApiPort,
             enabled: true,
             headless: true,
             viewport: { width: 390, height: 844 },

--- a/playground/nextjs-notes-demo/vitest.setup.ts
+++ b/playground/nextjs-notes-demo/vitest.setup.ts
@@ -68,7 +68,10 @@ const TEST_NOW = "2026-05-06T00:00:00.000Z";
 let base: PGlite;
 let currentDbClient: PGlite | undefined;
 let pointerResetTarget: HTMLElement | undefined;
-const worker = setupWorker(...nextCacheProbeFetchHandler, ...nextRscRequestHandlers);
+const worker = setupWorker(
+  ...nextCacheProbeFetchHandler,
+  ...(nextRscRequestHandlers as unknown as Parameters<typeof setupWorker>),
+);
 
 // Vitest mounts React into an existing document. Route tests intentionally let
 // the plugin render RootLayout's <html>/<body> tags into that mount so the

--- a/playground/rsc-vitest-demo/src/async-local-storage/concurrent.test.ts
+++ b/playground/rsc-vitest-demo/src/async-local-storage/concurrent.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "vitest";
+import { getCurrentUser, userAsyncStorage } from "./user-storage";
+
+const startTogether = createBarrier(2);
+const firstEntered = deferred<void>();
+const secondEntered = deferred<void>();
+
+test.concurrent("keeps the first AsyncLocalStorage run isolated across awaits", async () => {
+  await startTogether();
+
+  await userAsyncStorage.run(
+    {
+      user: {
+        name: "Ada Lovelace",
+        role: "admin",
+      },
+    },
+    async () => {
+      expect(getCurrentUser().name).toBe("Ada Lovelace");
+      firstEntered.resolve();
+      await secondEntered.promise;
+      await Promise.resolve();
+      expect(getCurrentUser()).toEqual({
+        name: "Ada Lovelace",
+        role: "admin",
+      });
+    },
+  );
+});
+
+test.concurrent("keeps the second AsyncLocalStorage run isolated across awaits", async () => {
+  await startTogether();
+  await firstEntered.promise;
+
+  await userAsyncStorage.run(
+    {
+      user: {
+        name: "Grace Hopper",
+        role: "maintainer",
+      },
+    },
+    async () => {
+      expect(getCurrentUser().name).toBe("Grace Hopper");
+      secondEntered.resolve();
+      await Promise.resolve();
+      expect(getCurrentUser()).toEqual({
+        name: "Grace Hopper",
+        role: "maintainer",
+      });
+    },
+  );
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolve_) => {
+    resolve = resolve_;
+  });
+
+  return { promise, resolve };
+}
+
+function createBarrier(count: number) {
+  let waiting = 0;
+  const ready = deferred<void>();
+
+  return () => {
+    waiting++;
+    if (waiting === count) {
+      ready.resolve();
+    }
+    return ready.promise;
+  };
+}

--- a/playground/rsc-vitest-demo/vitest.config.ts
+++ b/playground/rsc-vitest-demo/vitest.config.ts
@@ -2,8 +2,14 @@ import { defineConfig } from "vitest/config";
 import { playwright } from "@vitest/browser-playwright";
 import { vitestPluginRSC } from "vitest-plugin-rsc";
 
+// oxlint-disable-next-line no-process-env
+const browserApiPort = Number(process.env.VITEST_BROWSER_API_PORT ?? 64123);
+
 export default defineConfig({
   plugins: [vitestPluginRSC()],
+  optimizeDeps: {
+    include: ["vitest-plugin-rsc > unctx"],
+  },
   test: {
     coverage: {
       provider: "v8",
@@ -13,6 +19,7 @@ export default defineConfig({
     },
     restoreMocks: true,
     browser: {
+      api: browserApiPort,
       enabled: true,
       headless: true,
       provider: playwright(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,12 +38,15 @@ importers:
 
   packages/vitest-plugin-rsc:
     dependencies:
+      '@babel/parser':
+        specifier: ^7.29.3
+        version: 7.29.3
       '@jridgewell/gen-mapping':
         specifier: ^0.3.13
         version: 0.3.13
       '@vitejs/plugin-rsc':
         specifier: 0.5.26
-        version: 0.5.26(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.12(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0))
+        version: 0.5.26(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.12(@types/node@24.12.4))
       '@vitest/expect':
         specifier: 5.0.0-beta.2
         version: 5.0.0-beta.2
@@ -53,6 +56,12 @@ importers:
       convert-source-map:
         specifier: ^2.0.0
         version: 2.0.0
+      magic-string:
+        specifier: ^0.30.21
+        version: 0.30.21
+      unctx:
+        specifier: ^2.5.0
+        version: 2.5.0
     devDependencies:
       '@types/convert-source-map':
         specifier: ^2.0.3
@@ -71,10 +80,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       msw:
         specifier: ^2.14.6
-        version: 2.14.6(@types/node@24.12.4)(typescript@6.0.3)
+        version: 2.14.6(@types/node@24.12.4)
       next:
         specifier: ^16.2.6
-        version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -86,10 +95,10 @@ importers:
         version: 1.0.0
       tsdown:
         specifier: ^0.22.0
-        version: 0.22.0(@typescript/native-preview@7.0.0-dev.20260512.1)(tsx@4.21.0)(typescript@6.0.3)
+        version: 0.22.0
       vite:
         specifier: ^8.0.12
-        version: 8.0.12(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)
+        version: 8.0.12(@types/node@24.12.4)
 
   playground/nextjs-no-msw-demo:
     dependencies:
@@ -2238,6 +2247,11 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -4069,6 +4083,9 @@ packages:
   unconfig-core@7.5.0:
     resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
 
+  unctx@2.5.0:
+    resolution: {integrity: sha512-p+Rz9x0R7X+CYDkT+Xg8/GhpcShTlU8n+cf9OtOEf7zEQsNcCZO1dPKNRDqvUTaq+P32PMMkxWHwfrxkqfqAYg==}
+
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
@@ -4086,6 +4103,10 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  unplugin@2.3.11:
+    resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
+    engines: {node: '>=18.12.0'}
 
   until-async@3.0.2:
     resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
@@ -4207,6 +4228,9 @@ packages:
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -5656,6 +5680,20 @@ snapshots:
       vite: 8.0.12(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)
       vitefu: 1.1.3(vite@8.0.12(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0))
 
+  '@vitejs/plugin-rsc@0.5.26(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.12(@types/node@24.12.4))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.18
+      es-module-lexer: 2.1.0
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      srvx: 0.11.15
+      strip-literal: 3.1.0
+      turbo-stream: 3.2.0
+      vite: 8.0.12(@types/node@24.12.4)
+      vitefu: 1.1.3(vite@8.0.12(@types/node@24.12.4))
+
   '@vitest/browser-playwright@5.0.0-beta.2(msw@2.14.6(@types/node@24.12.4)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.12(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0))(vitest@5.0.0-beta.2)':
     dependencies:
       '@vitest/browser': 5.0.0-beta.2(msw@2.14.6(@types/node@24.12.4)(typescript@6.0.3))(vite@8.0.12(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0))(vitest@5.0.0-beta.2)
@@ -5752,6 +5790,8 @@ snapshots:
     dependencies:
       mime-types: 3.0.2
       negotiator: 1.0.0
+
+  acorn@8.16.0: {}
 
   agent-base@7.1.4: {}
 
@@ -6664,6 +6704,29 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msw@2.14.6(@types/node@24.12.4):
+    dependencies:
+      '@inquirer/confirm': 6.0.13(@types/node@24.12.4)
+      '@mswjs/interceptors': 0.41.9
+      '@open-draft/deferred-promise': 3.0.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.14.0
+      headers-polyfill: 5.0.1
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.11.11
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.1
+      type-fest: 5.6.0
+      until-async: 3.0.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+
   msw@2.14.6(@types/node@24.12.4)(typescript@6.0.3):
     dependencies:
       '@inquirer/confirm': 6.0.13(@types/node@24.12.4)
@@ -6723,6 +6786,30 @@ snapshots:
       '@next/swc-win32-x64-msvc': 16.2.6
       '@opentelemetry/api': 1.9.1
       babel-plugin-react-compiler: 1.0.0
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      '@next/env': 16.2.6
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.29
+      caniuse-lite: 1.0.30001792
+      postcss: 8.4.31
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      styled-jsx: 5.1.6(react@19.2.6)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.2.6
+      '@next/swc-darwin-x64': 16.2.6
+      '@next/swc-linux-arm64-gnu': 16.2.6
+      '@next/swc-linux-arm64-musl': 16.2.6
+      '@next/swc-linux-x64-gnu': 16.2.6
+      '@next/swc-linux-x64-musl': 16.2.6
+      '@next/swc-win32-arm64-msvc': 16.2.6
+      '@next/swc-win32-x64-msvc': 16.2.6
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -7048,7 +7135,7 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown-plugin-dts@0.25.0(@typescript/native-preview@7.0.0-dev.20260512.1)(rolldown@1.0.0)(typescript@6.0.3):
+  rolldown-plugin-dts@0.25.0(rolldown@1.0.0):
     dependencies:
       '@babel/generator': 8.0.0-rc.4
       '@babel/helper-validator-identifier': 8.0.0-rc.4
@@ -7059,9 +7146,6 @@ snapshots:
       get-tsconfig: 5.0.0-beta.5
       obug: 2.1.1
       rolldown: 1.0.0
-    optionalDependencies:
-      '@typescript/native-preview': 7.0.0-dev.20260512.1
-      typescript: 6.0.3
     transitivePeerDependencies:
       - oxc-resolver
 
@@ -7335,6 +7419,11 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.0
 
+  styled-jsx@5.1.6(react@19.2.6):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.6
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -7397,7 +7486,7 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tsdown@0.22.0(@typescript/native-preview@7.0.0-dev.20260512.1)(tsx@4.21.0)(typescript@6.0.3):
+  tsdown@0.22.0:
     dependencies:
       ansis: 4.3.0
       cac: 7.0.0
@@ -7408,15 +7497,12 @@ snapshots:
       obug: 2.1.1
       picomatch: 4.0.4
       rolldown: 1.0.0
-      rolldown-plugin-dts: 0.25.0(@typescript/native-preview@7.0.0-dev.20260512.1)(rolldown@1.0.0)(typescript@6.0.3)
+      rolldown-plugin-dts: 0.25.0(rolldown@1.0.0)
       semver: 7.8.0
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tree-kill: 1.2.2
       unconfig-core: 7.5.0
-    optionalDependencies:
-      tsx: 4.21.0
-      typescript: 6.0.3
     transitivePeerDependencies:
       - '@ts-macro/tsc'
       - '@typescript/native-preview'
@@ -7459,6 +7545,13 @@ snapshots:
       '@quansync/fs': 1.0.0
       quansync: 1.0.0
 
+  unctx@2.5.0:
+    dependencies:
+      acorn: 8.16.0
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+      unplugin: 2.3.11
+
   undici-types@7.16.0: {}
 
   undici-types@7.21.0: {}
@@ -7468,6 +7561,13 @@ snapshots:
   universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
+
+  unplugin@2.3.11:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      acorn: 8.16.0
+      picomatch: 4.0.4
+      webpack-virtual-modules: 0.6.2
 
   until-async@3.0.2: {}
 
@@ -7487,6 +7587,17 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vite@8.0.12(@types/node@24.12.4):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rolldown: 1.0.0
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 24.12.4
+      fsevents: 2.3.3
+
   vite@8.0.12(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
@@ -7504,6 +7615,10 @@ snapshots:
   vitefu@1.1.3(vite@8.0.12(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)):
     optionalDependencies:
       vite: 8.0.12(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)
+
+  vitefu@1.1.3(vite@8.0.12(@types/node@24.12.4)):
+    optionalDependencies:
+      vite: 8.0.12(@types/node@24.12.4)
 
   vitest@5.0.0-beta.2(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@5.0.0-beta.2)(@vitest/coverage-v8@5.0.0-beta.2)(@vitest/ui@5.0.0-beta.2)(msw@2.14.6(@types/node@24.12.4)(typescript@6.0.3))(vite@8.0.12(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)):
     dependencies:
@@ -7537,6 +7652,8 @@ snapshots:
       - msw
 
   web-streams-polyfill@3.3.3: {}
+
+  webpack-virtual-modules@0.6.2: {}
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
## Summary

- adds an unctx-powered compile-time async context transform for browser awaits
- routes Next app-render request/action/render async storage through the browser ALS shim using nested `.run()` calls instead of `enterWith`
- keeps ReadableStream lifecycles and nested async helper awaits inside the correct request frame
- adds concurrent ALS coverage, Next request-context coverage, and non-default browser API ports for playground suites
- pre-optimizes `unctx` in the Next playgrounds so browser-mode CI does not reload tests mid-import

## Validation

- `pnpm --dir packages/vitest-plugin-rsc exec vitest run src/async-local-storage.test.ts src/async-local-storage-transform.test.ts`
- `pnpm --dir packages/vitest-plugin-rsc run build`
- `pnpm tsgo --build`
- `pnpm format:check`
- `pnpm lint`
- `VITEST_BROWSER_API_PORT=64123 pnpm --dir playground/rsc-vitest-demo exec vitest run`
- `VITEST_BROWSER_API_PORT=64124 pnpm --dir playground/nextjs-notes-demo exec vitest run`
- `VITEST_BROWSER_API_PORT=64125 pnpm --dir playground/nextjs-no-msw-demo exec vitest run`