### PR TITLE
fix: stabilize Vitest browser websocket fallback

### DIFF
--- a/packages/vitest-plugin-rsc/src/index.test.ts
+++ b/packages/vitest-plugin-rsc/src/index.test.ts
@@ -12,7 +12,7 @@ afterEach(async () => {
 });
 
 test("moves the Vitest browser API server before Vite falls back from an occupied port", async () => {
-  const occupiedPort = await occupyPort();
+  const occupiedPort = await occupyPort("localhost");
   const server = createViteServer([browserPlugin], { port: occupiedPort });
 
   await configureServer.call({} as never, server);
@@ -33,6 +33,18 @@ test.each([
   expect(server.config.server.port).toBe(occupiedPort);
 });
 
+test("does not hide non-port listen failures", async () => {
+  const server = createViteServer([browserPlugin], {
+    port: 0,
+    host: "invalid.invalid",
+  });
+
+  await expect(configureServer.call({} as never, server)).rejects.toMatchObject({
+    code: "ENOTFOUND",
+  });
+  expect(server.config.server.port).toBe(0);
+});
+
 function getPlugin(name: string): Plugin {
   const plugin = vitestPluginRSC().find((candidate) => candidate.name === name);
   if (!plugin) throw new Error(`Could not find ${name}.`);
@@ -48,18 +60,22 @@ function getHookHandler<T extends (...args: never[]) => unknown>(
 
 function createViteServer(
   plugins: Array<{ name: string }>,
-  server: { port: number; strictPort?: boolean },
+  server: {
+    port: number;
+    strictPort?: boolean;
+    host?: ViteDevServer["config"]["server"]["host"];
+  },
 ): ViteDevServer {
   return {
     config: { plugins, server },
   } as unknown as ViteDevServer;
 }
 
-function occupyPort() {
+function occupyPort(host?: string) {
   return new Promise<number>((resolve, reject) => {
     const server = createServer();
     server.once("error", reject);
-    server.listen(0, () => {
+    server.listen({ port: 0, host }, () => {
       servers.push(server);
       resolve((server.address() as { port: number }).port);
     });

--- a/packages/vitest-plugin-rsc/src/index.test.ts
+++ b/packages/vitest-plugin-rsc/src/index.test.ts
@@ -1,0 +1,73 @@
+import { createServer, type Server } from "node:net";
+import type { Plugin, ViteDevServer } from "vite";
+import { afterEach, expect, test } from "vitest";
+import { vitestPluginRSC } from "./index";
+
+const servers: Server[] = [];
+const browserPlugin = { name: "vitest:browser:config" };
+const configureServer = getHookHandler(getPlugin("rsc:browser-api-port").configureServer);
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map(closeServer));
+});
+
+test("moves the Vitest browser API server before Vite falls back from an occupied port", async () => {
+  const occupiedPort = await occupyPort();
+  const server = createViteServer([browserPlugin], { port: occupiedPort });
+
+  await configureServer.call({} as never, server);
+
+  expect(server.config.server.port).toEqual(expect.any(Number));
+  expect(server.config.server.port).not.toBe(occupiedPort);
+});
+
+test.each([
+  ["strict Vitest browser API ports", [browserPlugin], { strictPort: true }],
+  ["non-browser Vite servers", [], {}],
+])("leaves %s untouched", async (_name, plugins, options) => {
+  const occupiedPort = await occupyPort();
+  const server = createViteServer(plugins, { port: occupiedPort, ...options });
+
+  await configureServer.call({} as never, server);
+
+  expect(server.config.server.port).toBe(occupiedPort);
+});
+
+function getPlugin(name: string): Plugin {
+  const plugin = vitestPluginRSC().find((candidate) => candidate.name === name);
+  if (!plugin) throw new Error(`Could not find ${name}.`);
+  return plugin;
+}
+
+function getHookHandler<T extends (...args: never[]) => unknown>(
+  hook: T | { handler: T } | undefined,
+): T {
+  if (!hook) throw new Error("Expected Vite hook to be defined.");
+  return typeof hook === "function" ? hook : hook.handler;
+}
+
+function createViteServer(
+  plugins: Array<{ name: string }>,
+  server: { port: number; strictPort?: boolean },
+): ViteDevServer {
+  return {
+    config: { plugins, server },
+  } as unknown as ViteDevServer;
+}
+
+function occupyPort() {
+  return new Promise<number>((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, () => {
+      servers.push(server);
+      resolve((server.address() as { port: number }).port);
+    });
+  });
+}
+
+function closeServer(server: Server) {
+  return new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}

--- a/packages/vitest-plugin-rsc/src/index.ts
+++ b/packages/vitest-plugin-rsc/src/index.ts
@@ -171,12 +171,31 @@ async function resolveBrowserApiPort(
   port: number,
   host: ViteDevServer["config"]["server"]["host"],
 ) {
-  const listenHost = typeof host === "string" ? host : undefined;
+  const listenHost = resolveViteListenHost(host);
   try {
     return await listenOnAvailablePort(port, listenHost);
-  } catch {
+  } catch (error) {
+    if (!isAddressInUse(error)) {
+      throw error;
+    }
     return await listenOnAvailablePort(0, listenHost);
   }
+}
+
+function resolveViteListenHost(host: ViteDevServer["config"]["server"]["host"]) {
+  if (host === undefined || host === false) {
+    return "localhost";
+  }
+  if (host === true) {
+    return undefined;
+  }
+  return host;
+}
+
+function isAddressInUse(error: unknown): boolean {
+  return (
+    typeof error === "object" && error !== null && "code" in error && error.code === "EADDRINUSE"
+  );
 }
 
 function listenOnAvailablePort(port: number, host: string | undefined) {

--- a/packages/vitest-plugin-rsc/src/index.ts
+++ b/packages/vitest-plugin-rsc/src/index.ts
@@ -1,3 +1,4 @@
+import { createServer } from "node:net";
 import { type Plugin, type ViteDevServer } from "vite";
 import { vitePluginRscMinimal } from "@vitejs/plugin-rsc/plugin";
 import { createReactClientCoveragePlugin } from "./coverage";
@@ -16,6 +17,7 @@ type ReactClientWebSocketInvoke = {
 
 export function vitestPluginRSC(): Plugin[] {
   return [
+    createBrowserApiPortPlugin(),
     ...vitePluginRscMinimal({
       environment: {
         browser: "react_client",
@@ -137,6 +139,56 @@ export function vitestPluginRSC(): Plugin[] {
     },
     createReactClientCoveragePlugin(),
   ];
+}
+
+function createBrowserApiPortPlugin(): Plugin {
+  return {
+    name: "rsc:browser-api-port",
+    async configureServer(server) {
+      if (
+        !isVitestBrowserServer(server) ||
+        server.config.server.strictPort ||
+        typeof server.config.server.port !== "number"
+      ) {
+        return;
+      }
+
+      // Vite injects /@vite/client before listen(). Avoid Vite's later port
+      // fallback path so the browser receives the final server port up front.
+      server.config.server.port = await resolveBrowserApiPort(
+        server.config.server.port,
+        server.config.server.host,
+      );
+    },
+  };
+}
+
+function isVitestBrowserServer(server: ViteDevServer): boolean {
+  return server.config.plugins.some((plugin) => plugin.name === "vitest:browser:config");
+}
+
+async function resolveBrowserApiPort(
+  port: number,
+  host: ViteDevServer["config"]["server"]["host"],
+) {
+  const listenHost = typeof host === "string" ? host : undefined;
+  try {
+    return await listenOnAvailablePort(port, listenHost);
+  } catch {
+    return await listenOnAvailablePort(0, listenHost);
+  }
+}
+
+function listenOnAvailablePort(port: number, host: string | undefined) {
+  return new Promise<number>((resolve, reject) => {
+    const server = createServer();
+    server.unref();
+    server.once("error", reject);
+    server.listen({ port, host }, () => {
+      const address = server.address();
+      server.close(() => resolve(typeof address === "object" && address ? address.port : port));
+    });
+  });
 }
 
 function parseWebSocketInvoke(raw: unknown): ReactClientWebSocketInvoke | undefined {


### PR DESCRIPTION
## Summary

- Resolve Vitest Browser API port collisions before Vite starts listening instead of rewriting the Vite client.
- Only applies inside the Vitest browser server (`vitest:browser:config`) and leaves strict-port setups untouched.
- Add focused tests for occupied-port reassignment, strict port behavior, and non-browser Vite servers.

## Root Cause

Vite injects `/@vite/client` during server startup before the HTTP server has completed `listen()`. If the configured Vitest Browser API port is already occupied, Vite can later fall back to another port, while the client-side websocket config may still reflect the stale pre-listen port. Moving the browser server to an available OS-picked port before Vite reaches that fallback path avoids the stale client configuration without patching Vite client code.

## Validation

- `pnpm exec oxfmt --check packages/vitest-plugin-rsc/src/index.ts packages/vitest-plugin-rsc/src/index.test.ts`
- `pnpm exec oxlint packages/vitest-plugin-rsc/src/index.ts packages/vitest-plugin-rsc/src/index.test.ts`
- `pnpm --dir packages/vitest-plugin-rsc exec vitest run`
- `pnpm --dir packages/vitest-plugin-rsc run build`
- `63315` intentionally occupied + `pnpm --dir playground/nextjs-notes-demo exec vitest run app/notes/page.test.tsx --browser.fileParallelism=false --testTimeout 15000`
