### PR TITLE
fix: match Vite browser port probing

### DIFF
--- a/packages/vitest-plugin-rsc/src/index.test.ts
+++ b/packages/vitest-plugin-rsc/src/index.test.ts
@@ -12,7 +12,7 @@ afterEach(async () => {
 });
 
 test("moves the Vitest browser API server before Vite falls back from an occupied port", async () => {
-  const occupiedPort = await occupyPort("localhost");
+  const occupiedPort = await occupyPort();
   const server = createViteServer([browserPlugin], { port: occupiedPort });
 
   await configureServer.call({} as never, server);

--- a/packages/vitest-plugin-rsc/src/index.ts
+++ b/packages/vitest-plugin-rsc/src/index.ts
@@ -193,8 +193,11 @@ async function resolveBrowserApiPort(
 }
 
 function resolveViteListenHost(host: ViteDevServer["config"]["server"]["host"]) {
+  // Match Vite's default listen call. Checking "localhost" can miss ports that
+  // are unavailable for wildcard binds, which lets Vite fall back after
+  // /@vite/client has already captured the old port.
   if (host === undefined || host === false) {
-    return "localhost";
+    return undefined;
   }
   if (host === true) {
     return undefined;


### PR DESCRIPTION
I'm an implementer: Fixes the Vitest browser websocket port mismatch when the default browser API port is unavailable for Vite's wildcard listen call.

Root cause:
- Vitest browser starts from default port 63315.
- Vite injects /@vite/client before listen().
- The plugin preflight checked localhost, but Vite later listens with wildcard host semantics when host is unset.
- A port can be available on localhost while unavailable for wildcard binds, so Vite fell back after the browser client had already captured the old port.

Change:
- Match Vite default listen semantics by probing wildcard/undefined when server.host is unset or false.
- Update the regression test to occupy the wildcard port instead of localhost only.

Validation:
- pnpm --filter vitest-plugin-rsc test:run src/index.test.ts
- pnpm build
- CI=1 pnpm test:run --project nextjs-no-msw-demo --api 52661
- pnpm tsgo --build
- pnpm lint:ci
- pnpm format:check
- git diff --check
